### PR TITLE
General improvements and bug fixes

### DIFF
--- a/olympus.sh
+++ b/olympus.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 # Olympus launch script bundled with Linux and macOS builds.
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit 1
 
 if [ -f "olympus.new.love" ]; then
     if [ -n "${OLYMPUS_RESTARTER_PID+x}" ]; then
         attempt=0
         while [ "$attempt" -lt 30 ] && kill -0 "$OLYMPUS_RESTARTER_PID"; do
-            attempt=$(( attempt + 1 ))
+            attempt=$((attempt + 1))
             sleep 0.1
         done
     fi
@@ -16,17 +16,19 @@ if [ -f "olympus.new.love" ]; then
     mv "olympus.new.love" "olympus.love"
 fi
 
-if [ "$UNAME" == "Darwin" ]; then
-	export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:$(pwd)"
+if [ "$(uname)" = "Darwin" ]; then
+    DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:$(pwd)"
+    export DYLD_LIBRARY_PATH
 else
-    export LD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:$(pwd)"
+    LD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:$(pwd)"
+    export LD_LIBRARY_PATH
 fi
 
 if [ -f "love" ]; then
     ./love --fused olympus.love $@
-elif command -v love &> /dev/null; then
+elif command -v love >/dev/null 2>&1; then
     love --fused olympus.love $@
-elif command -v love2d &> /dev/null; then
+elif command -v love2d >/dev/null 2>&1; then
     love2d --fused olympus.love $@
 else
     echo "love2d not found!"


### PR DESCRIPTION
Line 4: Made the script exit with error code 1 in the case that `cd` fails.
Line 19: The variable `$UNAME` is undefined on most shells, using the command `uname` is an easy fix. Also `==` doesn't exist in posix shell (which I assume is the goal based off of the shebang, and if not it still makes it more portable).
Lines 20-24: Exporting on a separate line avoids the return value of `pwd` from being ignored.
Lines 29/31: `&>/dev/null` doesn't work in posix shell, `>/dev/null 2>&1` works though and is more portable.