### PR TITLE
Added filter and sorting to GameBanana screen through dropdowns

### DIFF
--- a/src/scenes/gamebanana.lua
+++ b/src/scenes/gamebanana.lua
@@ -121,9 +121,9 @@ local root = uie.column({
                         self.realX = math.floor(self.parent.width * 0.5 - self.width * 0.5)
                     else
                         -- there is no search so the dropdowns are shown: center the title between the "open GB" button and the dropdowns.
-                        openGameBananaButton = scene.root:findChild("openGameBananaButton")
-                        rightRow = scene.root:findChild("rightRow")
-                        width = self.parent.innerWidth - openGameBananaButton.width - rightRow.width
+                        local openGameBananaButton = scene.root:findChild("openGameBananaButton")
+                        local rightRow = scene.root:findChild("rightRow")
+                        local width = self.parent.innerWidth - openGameBananaButton.width - rightRow.width
                         self.x = math.floor(width * 0.5 - self.width * 0.5 + openGameBananaButton.width)
                         self.realX = math.floor(width * 0.5 - self.width * 0.5 + openGameBananaButton.width)
                     end
@@ -350,7 +350,7 @@ function scene.load()
     
     -- Load the categories / item types list upon entering the GameBanana screen
     threader.routine(function()
-        data, msg = threader.wrap("utils").downloadYAML("https://max480-random-stuff.appspot.com/celeste/gamebanana-categories"):result()
+        local data, msg = threader.wrap("utils").downloadYAML("https://max480-random-stuff.appspot.com/celeste/gamebanana-categories"):result()
         
         if not data then
             -- Error while calling the API
@@ -362,13 +362,13 @@ function scene.load()
             }):with(uiu.bottombound):with(uiu.rightbound):as("error"))
         else
             -- Convert the list retrieved from the API to a dropdown option list
-            allTypes = {}
+            local allTypes = {}
             for _, category in ipairs(data) do
                 table.insert(allTypes, { text = category.formatted .. " (" .. category.count .. ")", data = category.itemtype })
             end
             
             -- Refresh the dropdown
-            itemtypeFilterDropdown = scene.root:findChild("itemtypeFilter")
+            local itemtypeFilterDropdown = scene.root:findChild("itemtypeFilter")
             itemtypeFilterDropdown.data = allTypes
             itemtypeFilterDropdown:setText(allTypes[1].text)
             itemtypeFilterDropdown:reflow()

--- a/src/scenes/gamebanana.lua
+++ b/src/scenes/gamebanana.lua
@@ -389,7 +389,7 @@ function scene.downloadEntries(page)
         return scene.downloadFeaturedEntries()
     end
 
-    local url = "https://api.gamebanana.com/Core/List/New?gameid=6460&page=" .. tostring(page) .. (scene.itemtypeFilter ~= "" and "&itemtype=" .. scene.itemtypeFilter or "")
+    local url = "https://api.gamebanana.com/Core/List/New?format=json_min&gameid=6460&page=" .. tostring(page) .. (scene.itemtypeFilter ~= "" and "&itemtype=" .. scene.itemtypeFilter or "")
     local data = scene.cache[url]
     if data ~= nil then
         return data
@@ -488,7 +488,7 @@ function scene.downloadInfo(entries, id)
             mcitem(i, "fields", "Withhold().bIsWithheld(),name,Owner().name,date,description,text,views,likes,downloads,screenshots,Files().aFiles(),Url().sGetProfileUrl()")
     end
 
-    local url = "https://api.gamebanana.com/Core/Item/Data?" .. multicall:sub(2)
+    local url = "https://api.gamebanana.com/Core/Item/Data?format=json_min&" .. multicall:sub(2)
     local data = scene.cache[url]
     if data ~= nil then
         return data


### PR DESCRIPTION
This is how those dropdowns look like (with the narrowest window size and both longest option names):

![image](https://user-images.githubusercontent.com/52103563/106366464-54649e80-633c-11eb-99ed-e586e85d44a7.png)

- When applying a sort **other than "most recent"**, Olympus calls the [GameBanana sorted list API from max480-random-stuff](https://github.com/max4805/RandomStuffWebsite#the-gamebanana-sorted-list-api), that has the same format as the already implemented search API.
- When applying the "most recent" sort, the GameBanana API is called directly, because [Core/List/New supports filtering by itemtype](https://api.gamebanana.com/docs/endpoints/Core/List/New), and my APIs can be up to 30 minutes behind (which is not much of an issue with "most downloaded", but becomes one for "most recent").
- To get a list of categories to display on the filter dropdown, it calls [a new category list API on max480-random-stuff](https://github.com/max4805/RandomStuffWebsite#gamebanana-categories-list-api) that provides a list of categories _that are not empty_, along with how many submissions each have.

This PR also changes the format of API calls to GameBanana to `json_min`, which doesn't change the contents but minifies JSON output. On the calls I tested that on, the amount of data downloaded decreased from 658 KB to 201 KB, taking about 1.5 seconds to download on my ~~excellent~~ Internet connection instead of about 4.