### PR TITLE
Use new "webp to png" API to display missing images on GameBanana

### DIFF
--- a/src/scenes/gamebanana.lua
+++ b/src/scenes/gamebanana.lua
@@ -831,14 +831,12 @@ function scene.item(info)
             return status and rv
         end
 
-        if not screenshots[1]._sFile:match("%.webp$") then
-            -- TODO: WEBP SUPPORT
-            img = downloadImage(screenshots[1]._sFile, "https://screenshots.gamebanana.com/" .. screenshots[1]._sRelativeImageDir .. "/" .. (screenshots[1]._sFile220 or screenshots[1]._sFile100))
-        end
+        img = downloadImage(screenshots[1]._sFile, (screenshots[1]._sFile:match("%.webp$") and "https://max480-random-stuff.appspot.com/celeste/webp-to-png?src=" or "") ..
+            "https://screenshots.gamebanana.com/" .. screenshots[1]._sRelativeImageDir .. "/" .. (screenshots[1]._sFile220 or screenshots[1]._sFile100))
 
-        if screenshots[2] and not screenshots[2]._sFile:match("%.webp$") then
-            -- TODO: WEBP SUPPORT
-            bg = downloadImage(screenshots[2]._sFile, "https://screenshots.gamebanana.com/" .. screenshots[2]._sRelativeImageDir .. "/" .. screenshots[2]._sFile)
+        if screenshots[2] then
+            bg = downloadImage(screenshots[2]._sFile, (screenshots[2]._sFile:match("%.webp$") and "https://max480-random-stuff.appspot.com/celeste/webp-to-png?src=" or "") ..
+                "https://screenshots.gamebanana.com/" .. screenshots[2]._sRelativeImageDir .. "/" .. screenshots[2]._sFile)
         end
 
         bg = bg or img


### PR DESCRIPTION
WebP support looks particularly fun, with some native libraries being involved, so I just decided to throw the problem on the backend side, because I could. 😅 There's a new API that can convert WebP pictures to PNG now. (It only accepts screenshots.gamebanana.com URLs so it can't be used as a magic converter API for everything.)

For example:
- webp: https://screenshots.gamebanana.com/img/ss/gamefiles/5b05ac2b4b6da.webp
- png: https://max480-random-stuff.appspot.com/celeste/webp-to-png?src=https://screenshots.gamebanana.com/img/ss/gamefiles/5b05ac2b4b6da.webp

Do tell me if you have better plans or if you have a problem with me hosting more stuff - I sure have no problem with it. 😄 I swear I don't have more APIs planned though.

This is particularly visible on "Most Downloaded Game files":
![image](https://user-images.githubusercontent.com/52103563/106400447-aed62b80-641e-11eb-9fd9-5e29814262f7.png)

➡️ 

![image](https://user-images.githubusercontent.com/52103563/106400460-cc0afa00-641e-11eb-8633-c224b3a04604.png)
