### PR TITLE
Set response header to lowercase

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -157,7 +157,7 @@ function utils.download(url, headers)
         return body
 
     elseif code >= 300 and code <= 399 then
-        local redirect = response.headers["Location"]:match("^%s*(.*)%s*$")
+        local redirect = response.headers["location"]:match("^%s*(.*)%s*$")
         headers["Referer"] = url
         return utils.download(redirect, headers)
     end


### PR DESCRIPTION
This fixes an issue I was having where the application would crash with a key-not-found error in some cases when accessing max480's webp-to-png api. Please test this on Windows before merging; it's possible that it does something different with header case and there needs to be some sort of platform-based check.