### PR TITLE
[Linux] feat: add Steam flatpak support

### DIFF
--- a/src/finder.lua
+++ b/src/finder.lua
@@ -36,6 +36,8 @@ function finder.findSteamRoot()
         local paths = {
             fs.joinpath(os.getenv("HOME"), ".local", "share", "Steam"),
             fs.joinpath(os.getenv("HOME"), ".steam", "steam"),
+            fs.joinpath(os.getenv("HOME"), ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam"),
+            fs.joinpath(os.getenv("HOME"), ".var", "app", "com.valvesoftware.Steam", ".steam", "steam"),
         }
 
         for i = 1, #paths do


### PR DESCRIPTION
The Steam flatpak on Linux exists inside `~/.var/app/com.valvesoftware.Steam` which Olympus doesn't look for.
This PR adds those paths to `finder`!
