### PR TITLE
Some nitpicks for the GameBanana browser

### DIFF
--- a/src/scenes/gamebanana.lua
+++ b/src/scenes/gamebanana.lua
@@ -670,10 +670,6 @@ function scene.item(info)
                                     end
                                 end
 
-                                table.sort(btns, function(a, b)
-                                    return a._tsDateAdded > b._tsDateAdded
-                                end)
-
                                 for i = 1, #btns do
                                     local file = btns[i]
                                     btns[i] = uie[i == 1 and "buttonGreen" or "button"](

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -108,7 +108,7 @@ function utils.concat(...)
 end
 
 function utils.toURLComponent(value)
-    return value and value:gsub("([^%w _%%%-%.~])", function(c) return string.format("%%%02X", string.byte(c)) end):gsub(" ", "+")
+    return value and value:gsub("([^%w _%-%.~])", function(c) return string.format("%%%02X", string.byte(c)) end):gsub(" ", "+")
 end
 
 function utils.fromURLComponent(value)


### PR DESCRIPTION
- Removed the sort by descending date applied on files: GameBanana sends the list in the order they are displayed on the site, and Olympus should probably follow it. 😅 Differences can be seen on Spring Collab and D-Sides
- Prevent 400 errors when searching for '%': it can be seen by trying to search "114%". The % needs to be encoded as well for the URL parameter to be valid:
```js
decodeURIComponent("114%")
> Uncaught URIError: malformed URI sequence
decodeURIComponent("114%25")
> "114%"
```