### PR TITLE
Integrate new GameBanana v5 APIs

### DIFF
--- a/src/scenes/gamebanana.lua
+++ b/src/scenes/gamebanana.lua
@@ -316,7 +316,7 @@ function scene.load()
 
     -- Load the categories list upon entering the GameBanana screen
     threader.routine(function()
-        local data, msg = threader.wrap("utils").downloadJSON("https://gamebanana.com/apiv3/ModCategory/ByGame?_aGameRowIds[]=6460&_sRecordSchema=Custom&_csvProperties=_idRow,_sName,_idParentCategoryRow&_nPerpage=50"):result()
+        local data, msg = threader.wrap("utils").downloadJSON("https://gamebanana.com/apiv5/ModCategory/ByGame?_aGameRowIds[]=6460&_sRecordSchema=Custom&_csvProperties=_idRow,_sName,_idParentCategoryRow&_nPerpage=50"):result()
 
         if not data then
             -- Error while calling the API
@@ -381,16 +381,18 @@ end
 function scene.downloadSortedEntries(page, sort, categoryFilter, featured)
     local url
     if categoryFilter ~= "" then
-        url = "https://gamebanana.com/apiv3/Mod/ByCategory?_aCategoryRowIds[]=" .. categoryFilter
+        url = "https://gamebanana.com/apiv5/Mod/ByCategory?_aCategoryRowIds[]=" .. categoryFilter
     else
-        url = "https://gamebanana.com/apiv3/Mod/ByGame?_aGameRowIds[]=6460"
+        url = "https://gamebanana.com/apiv5/Mod/ByGame?_aGameRowIds[]=6460"
 
         if featured then
             url = url .. "&_aArgs[]=_sbWasFeatured%20%3D%20true"
         end
     end
 
-    url = url .. "&_sRecordSchema=Olympus&_sOrderBy=" .. sort .. ",DESC&_nPage=" .. (featured and 1 or page) .. "&_nPerpage=20"
+    url = url ..
+        "&_csvProperties=_sName,_sProfileUrl,_aSubmitter,_tsDateAdded,_aPreviewMedia,_sDescription,_sText,_nViewCount,_nLikeCount,_nDownloadCount,_aFiles,_aModManagerIntegrations&_sOrderBy=" .. sort .. ",DESC" ..
+        "&_nPage=" .. (featured and 1 or page) .. "&_nPerpage=20"
 
     local data = scene.cache[url]
     if data ~= nil then

--- a/src/scenes/gamebanana.lua
+++ b/src/scenes/gamebanana.lua
@@ -316,7 +316,7 @@ function scene.load()
 
     -- Load the categories list upon entering the GameBanana screen
     threader.routine(function()
-        local data, msg = threader.wrap("utils").downloadJSON("https://gamebanana.com/apiv6/ModCategory/ByGame?_aGameRowIds[]=6460&_sRecordSchema=Custom&_csvProperties=_idRow,_sName,_idParentCategoryRow&_nPerpage=50"):result()
+        local data, msg = threader.wrap("utils").downloadJSON("https://gamebanana.com/apiv5/ModCategory/ByGame?_aGameRowIds[]=6460&_sRecordSchema=Custom&_csvProperties=_idRow,_sName,_idParentCategoryRow&_nPerpage=50"):result()
 
         if not data then
             -- Error while calling the API
@@ -364,8 +364,7 @@ end
 
 
 function scene.downloadSearchEntries(query)
-    local url = "https://gamebanana.com/apiv6/Mod/ByName?_sName=*" .. utils.toURLComponent(query) .. "*&_nPerpage=20&_idGameRow=6460" ..
-	  "&_csvProperties=_sName,_sProfileUrl,_aSubmitter,_tsDateAdded,_aPreviewMedia,_sDescription,_sText,_nViewCount,_nLikeCount,_nDownloadCount,_aFiles,_aModManagerIntegrations"
+    local url = "https://max480-random-stuff.appspot.com/celeste/gamebanana-search?version=2&q=" .. utils.toURLComponent(query)
     local data = scene.cache[url]
     if data ~= nil then
         return data
@@ -382,9 +381,9 @@ end
 function scene.downloadSortedEntries(page, sort, categoryFilter, featured)
     local url
     if categoryFilter ~= "" then
-        url = "https://gamebanana.com/apiv6/Mod/ByCategory?_aCategoryRowIds[]=" .. categoryFilter
+        url = "https://gamebanana.com/apiv5/Mod/ByCategory?_aCategoryRowIds[]=" .. categoryFilter
     else
-        url = "https://gamebanana.com/apiv6/Mod/ByGame?_aGameRowIds[]=6460"
+        url = "https://gamebanana.com/apiv5/Mod/ByGame?_aGameRowIds[]=6460"
 
         if featured then
             url = url .. "&_aArgs[]=_sbWasFeatured%20%3D%20true"

--- a/src/scenes/gamebanana.lua
+++ b/src/scenes/gamebanana.lua
@@ -316,7 +316,7 @@ function scene.load()
 
     -- Load the categories list upon entering the GameBanana screen
     threader.routine(function()
-        local data, msg = threader.wrap("utils").downloadJSON("https://gamebanana.com/apiv3/ModCategory/ByGame?_aGameRowIds%5B%5D=6460&_sRecordSchema=Custom&_csvProperties=_idRow,_sName,_idParentCategoryRow&_nPerpage=50"):result()
+        local data, msg = threader.wrap("utils").downloadJSON("https://gamebanana.com/apiv3/ModCategory/ByGame?_aGameRowIds[]=6460&_sRecordSchema=Custom&_csvProperties=_idRow,_sName,_idParentCategoryRow&_nPerpage=50"):result()
 
         if not data then
             -- Error while calling the API
@@ -381,12 +381,12 @@ end
 function scene.downloadSortedEntries(page, sort, categoryFilter, featured)
     local url
     if categoryFilter ~= "" then
-        url = "https://gamebanana.com/apiv3/Mod/ByCategory?_aCategoryRowIds%5B%5D=" .. categoryFilter
+        url = "https://gamebanana.com/apiv3/Mod/ByCategory?_aCategoryRowIds[]=" .. categoryFilter
     else
-        url = "https://gamebanana.com/apiv3/Mod/ByGame?_aGameRowIds%5B%5D=6460"
+        url = "https://gamebanana.com/apiv3/Mod/ByGame?_aGameRowIds[]=6460"
 
         if featured then
-            url = url .. "&_aArgs%5B%5D=_sbWasFeatured%20%3D%20true"
+            url = url .. "&_aArgs[]=_sbWasFeatured%20%3D%20true"
         end
     end
 

--- a/src/scenes/gamebanana.lua
+++ b/src/scenes/gamebanana.lua
@@ -686,13 +686,11 @@ function scene.item(info)
         end
 
         img = downloadImage(screenshots[1]._sFile100,
-            (screenshots[1]._sFile100:match("%.webp$") and "https://max480-random-stuff.appspot.com/celeste/webp-to-png?src=" or "") ..
-            screenshots[1]._sBaseUrl .. "/" .. screenshots[1]._sFile100)
+            screenshots[1]._sFile100:match("%.webp$") and getMirrorURLForWebp(screenshots[1]._sBaseUrl .. "/" .. screenshots[1]._sFile) or screenshots[1]._sBaseUrl .. "/" .. screenshots[1]._sFile100)
 
         if screenshots[2] then
-            bg = downloadImage(screenshots[2]._sFile,
-                (screenshots[2]._sFile:match("%.webp$") and "https://max480-random-stuff.appspot.com/celeste/webp-to-png?src=" or "") ..
-                screenshots[2]._sBaseUrl .. "/" .. screenshots[2]._sFile)
+            bg = downloadImage(screenshots[2]._sFile100,
+                screenshots[2]._sFile100:match("%.webp$") and getMirrorURLForWebp(screenshots[2]._sBaseUrl .. "/" .. screenshots[2]._sFile) or screenshots[2]._sBaseUrl .. "/" .. screenshots[2]._sFile100)
         end
 
         bg = bg or img
@@ -770,5 +768,12 @@ function scene.item(info)
     return item
 end
 
+-- Figures out the mirror URL for a given webp image, turning for instance https://images.gamebanana.com/img/ss/mods/5d5ae491a3cf5.webp
+-- into https://celestemodupdater.0x0a.de/banana-mirror-images/img_ss_mods_5d5ae491a3cf5.png.
+-- This allows Olympus to get those webp images converted to png.
+function getMirrorURLForWebp(image)
+    local _, _, path = string.find(image, "^https?://[^/]+/(.*)%.webp$")
+    return "https://celestemodupdater.0x0a.de/banana-mirror-images/" .. string.gsub(path, "/", "_") .. ".png"
+end
 
 return scene

--- a/src/scenes/gamebanana.lua
+++ b/src/scenes/gamebanana.lua
@@ -316,7 +316,7 @@ function scene.load()
 
     -- Load the categories list upon entering the GameBanana screen
     threader.routine(function()
-        local data, msg = threader.wrap("utils").downloadJSON("https://gamebanana.com/apiv5/ModCategory/ByGame?_aGameRowIds[]=6460&_sRecordSchema=Custom&_csvProperties=_idRow,_sName,_idParentCategoryRow&_nPerpage=50"):result()
+        local data, msg = threader.wrap("utils").downloadJSON("https://gamebanana.com/apiv6/ModCategory/ByGame?_aGameRowIds[]=6460&_sRecordSchema=Custom&_csvProperties=_idRow,_sName,_idParentCategoryRow&_nPerpage=50"):result()
 
         if not data then
             -- Error while calling the API
@@ -364,7 +364,8 @@ end
 
 
 function scene.downloadSearchEntries(query)
-    local url = "https://max480-random-stuff.appspot.com/celeste/gamebanana-search?version=2&q=" .. utils.toURLComponent(query)
+    local url = "https://gamebanana.com/apiv6/Mod/ByName?_sName=*" .. utils.toURLComponent(query) .. "*&_nPerpage=20&_idGameRow=6460" ..
+	  "&_csvProperties=_sName,_sProfileUrl,_aSubmitter,_tsDateAdded,_aPreviewMedia,_sDescription,_sText,_nViewCount,_nLikeCount,_nDownloadCount,_aFiles,_aModManagerIntegrations"
     local data = scene.cache[url]
     if data ~= nil then
         return data
@@ -381,9 +382,9 @@ end
 function scene.downloadSortedEntries(page, sort, categoryFilter, featured)
     local url
     if categoryFilter ~= "" then
-        url = "https://gamebanana.com/apiv5/Mod/ByCategory?_aCategoryRowIds[]=" .. categoryFilter
+        url = "https://gamebanana.com/apiv6/Mod/ByCategory?_aCategoryRowIds[]=" .. categoryFilter
     else
-        url = "https://gamebanana.com/apiv5/Mod/ByGame?_aGameRowIds[]=6460"
+        url = "https://gamebanana.com/apiv6/Mod/ByGame?_aGameRowIds[]=6460"
 
         if featured then
             url = url .. "&_aArgs[]=_sbWasFeatured%20%3D%20true"


### PR DESCRIPTION
This replaces calls to GameBanana APIs with their v3 counterparts. Instead of asking for a ID list then for details for each ID, Olympus can now get the details directly in one call. The "featured" and "search" APIs also follow the same format, so we don't need specific handling for each case, which simplifies the code by quite a bit.

This way, it also gets rid of the **sorted list** and **categories list** APIs from max480-random-stuff.appspot.com, which are now deprecated. The only APIs still used on my end are **search** (which was updated to return only mods, and in the same format as GameBanana APIs, so both results are parsed the same way) and **webp to png**.

This PR is ready to be merged by itself, but shouldn't since this makes every mod outside the Mod category inaccessible in Olympus, so the Tool category should be sorted out first.