### PR TITLE
Change shebang path for install.sh

### DIFF
--- a/lib-linux/install.sh
+++ b/lib-linux/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Olympus install script bundled with Linux builds.
 
 SRCDIR="$(dirname "$(realpath "$0")")"


### PR DESCRIPTION
Some linux distributions (nixOs, maybe gentoo, some others) don't store their binaries in /bin. AFAIK the standardized way to use bash (or any other program excluding `/bin/sh`) is `#!/usr/bin/env program`