### PR TITLE
Re-enable Megacanvas to fix various crashes

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -250,6 +250,7 @@ function love.load(args)
     ui.fontMono = love.graphics.newFont("data/fonts/Perfect DOS VGA 437.ttf", 16)
     ui.fontBig = love.graphics.newFont("data/fonts/Renogare-Regular.otf", 28)
     ui.fontMedium = love.graphics.newFont("data/fonts/Renogare-Regular.otf", 21)
+    ui.features.megacanvas = true
 
     overlay = uiu.image("overlay")
 


### PR DESCRIPTION
For example, pressing Escape on the main menu triggers this:

```
Error

blurrer.lua:26: attempt to call method 'draw' (a boolean value)


Traceback

blurrer.lua:26: in function '__draw'
ui/elements/main.lua:804: in function 'redraw'
ui/elements/basic.lua:206: in function '__draw'
ui/elements/main.lua:804: in function 'redraw'
ui/elements/basic.lua:206: in function '__draw'
ui/elements/main.lua:804: in function 'redraw'
ui/elements/main.lua:462: in function '__draw'
ui/elements/main.lua:804: in function 'redraw'
ui/main.lua:235: in function 'draw'
main.lua:787: in function 'draw'
main.lua:102: in function <main.lua:99>
[C]: in function 'xpcall'
```

and trying to run Everest freezes Olympus, leaving this in the console: `notify.lua:129: attempt to call method 'draw' (a boolean value)`

Re-enabling Megacanvas (that was disabled by default in OlympUI) seems to fix those issues. I'm not sure that's the way to go though, and I'm even less sure I put the instruction to do this in the right place in the code.