### PR TITLE
Improved error messages for common issues

### DIFF
--- a/src/scenes/everest.lua
+++ b/src/scenes/everest.lua
@@ -70,8 +70,9 @@ Use the latest ]], { 0.3, 0.8, 0.5, 1 }, "stable", { 1, 1, 1, 1 }, " or ", { 0.8
         }):with(uiu.styleDeep), function()
             -- Check for XNA installed
             local xnaInstalled =
-                registry.getKey([[HKLM\SOFTWARE\WOW6432Node\Microsoft\XNA\Framework\v4.0\Installed]]) or
-                registry.getKey([[HKLM\SOFTWARE\Microsoft\XNA\Framework\v4.0\Installed]])
+                love.system.getOS() == "Windows" and
+                (registry.getKey([[HKLM\SOFTWARE\WOW6432Node\Microsoft\XNA\Framework\v4.0\Installed]]) or
+                registry.getKey([[HKLM\SOFTWARE\Microsoft\XNA\Framework\v4.0\Installed]]))
             local install = scene.root:findChild("installs").selected
             install = install and install.data
             -- Check for any version before 1.4.0.0
@@ -91,7 +92,7 @@ Please update to the latest version before installing Everest.]],
                         end }
                     }
                 })
-            elseif love.system.getOS() == "Windows" and string.find(install.version, "xna") ~= nil and not xnaInstalled then
+            elseif string.find(install.version, "xna") ~= nil and not xnaInstalled then
                 alert({
                     body = [[
 It is required to install XNA before installing Everest.

--- a/src/scenes/everest.lua
+++ b/src/scenes/everest.lua
@@ -1,12 +1,14 @@
 local ui, uiu, uie = require("ui").quick()
 local utils = require("utils")
 local fs = require("fs")
+local registry = require("registry")
 local threader = require("threader")
 local scener = require("scener")
 local config = require("config")
 local sharp = require("sharp")
 local alert = require("alert")
 local mainmenu = scener.preload("mainmenu")
+require("love.system")
 
 local scene = {
     name = "Everest Installer"
@@ -66,6 +68,10 @@ Use the latest ]], { 0.3, 0.8, 0.5, 1 }, "stable", { 1, 1, 1, 1 }, " or ", { 0.8
             clip = false,
             cacheable = false
         }):with(uiu.styleDeep), function()
+            -- Check for XNA installed
+            local xnaInstalled =
+                registry.getKey([[HKLM\SOFTWARE\WOW6432Node\Microsoft\XNA\Framework\v4.0\Installed]]) or
+                registry.getKey([[HKLM\SOFTWARE\Microsoft\XNA\Framework\v4.0\Installed]])
             local install = scene.root:findChild("installs").selected
             install = install and install.data
             -- Check for any version before 1.4.0.0
@@ -80,7 +86,27 @@ Please update to the latest version before installing Everest.]],
                             container:close("OK")
                             scene.install()
                         end },
-                        { "OK", function(container)
+                        { "Cancel", function(container)
+                            container:close("OK")
+                        end }
+                    }
+                })
+            elseif love.system.getOS() == "Windows" and string.find(install.version, "xna") ~= nil and not xnaInstalled then
+                alert({
+                    body = [[
+It is required to install XNA before installing Everest.
+If this copy of Celeste comes from Steam, run Celeste normally to install XNA.
+Otherwise, manually install XNA using the button below.]],
+                    buttons = {
+                        { "Install XNA", function(container)
+                            container:close("OK")
+                            utils.openURL("https://www.microsoft.com/en-ca/download/details.aspx?id=20914")
+                        end },
+                        { "Attempt Installation Anyway", function(container)
+                            container:close("OK")
+                            scene.install()
+                        end },
+                        { "Cancel", function(container)
                             container:close("OK")
                         end }
                     }

--- a/src/scenes/everest.lua
+++ b/src/scenes/everest.lua
@@ -68,11 +68,6 @@ Use the latest ]], { 0.3, 0.8, 0.5, 1 }, "stable", { 1, 1, 1, 1 }, " or ", { 0.8
             clip = false,
             cacheable = false
         }):with(uiu.styleDeep), function()
-            -- Check for XNA installed
-            local xnaInstalled =
-                love.system.getOS() == "Windows" and
-                (registry.getKey([[HKLM\SOFTWARE\WOW6432Node\Microsoft\XNA\Framework\v4.0\Installed]]) or
-                registry.getKey([[HKLM\SOFTWARE\Microsoft\XNA\Framework\v4.0\Installed]]))
             local install = scene.root:findChild("installs").selected
             install = install and install.data
             -- Check for any version before 1.4.0.0
@@ -92,7 +87,9 @@ Please update to the latest version before installing Everest.]],
                         end }
                     }
                 })
-            elseif string.find(install.version, "xna") ~= nil and not xnaInstalled then
+            elseif love.system.getOS() == "Windows" and string.find(install.version, "xna") ~= nil and
+            not (registry.getKey([[HKLM\SOFTWARE\WOW6432Node\Microsoft\XNA\Framework\v4.0\Installed]]) or
+            registry.getKey([[HKLM\SOFTWARE\Microsoft\XNA\Framework\v4.0\Installed]])) then
                 alert({
                     body = [[
 It is required to install XNA before installing Everest.

--- a/src/scenes/everest.lua
+++ b/src/scenes/everest.lua
@@ -66,7 +66,28 @@ Use the latest ]], { 0.3, 0.8, 0.5, 1 }, "stable", { 1, 1, 1, 1 }, " or ", { 0.8
             clip = false,
             cacheable = false
         }):with(uiu.styleDeep), function()
-            scene.install()
+            local install = scene.root:findChild("installs").selected
+            install = install and install.data
+            -- Check for any version before 1.4.0.0
+            local minorVersion = install and tonumber(install.versionCeleste:match("^1%.(%d+)%."))
+            if minorVersion ~= nil and minorVersion < 4 then
+                alert({
+                    body = [[
+Your current version of Celeste is outdated.
+Please update to the latest version before installing Everest.]],
+                    buttons = {
+                        { "Attempt Installation Anyway", function(container)
+                            container:close("OK")
+                            scene.install()
+                        end },
+                        { "OK", function(container)
+                            container:close("OK")
+                        end }
+                    }
+                })
+            else
+                scene.install()
+            end
         end):hook({
             update = function(orig, self, ...)
                 local root = scene.root

--- a/src/scenes/installer.lua
+++ b/src/scenes/installer.lua
@@ -344,26 +344,6 @@ function scene.sharpTask(id, ...)
         local task = sharp[id](table.unpack(args)):result()
         local batch
         local last
-        local heuristicError
-        local heuristicErrors = {
-            {
-                "Unsupported version of Celeste:",
-                [[
-Your current version of Celeste is outdated.
-Please update to the latest version before installing Everest.
-
-If that doesn't help, y]]
-            },
-            {
-                "MonoModRules failed resolving Microsoft.Xna.Framework.Game",
-                [[
-It is required to install XNA before installing Everest.
-If this copy of Celeste comes from Steam, run Celeste normally to install XNA.
-Otherwise, manually install XNA from https://www.microsoft.com/en-ca/download/details.aspx?id=20914.
-
-If there are any problems, y]]
-            }
-        }
         repeat
             batch = sharp.pollWaitBatch(task):result()
             local all = batch[3]
@@ -372,13 +352,6 @@ If there are any problems, y]]
                 if update ~= nil then
                     if not last or last[1] ~= update[1] or last[2] ~= update[2] or last[3] ~= update[3] or last[4] ~= update[4] then
                         last = update
-                        if not heuristicError then
-                            for j = 1, #heuristicErrors do
-                                if string.find(update[1], heuristicErrors[j][1]) ~= nil then
-                                    heuristicError = heuristicErrors[j][2]
-                                end
-                            end
-                        end
                         scene.update(update[1], update[2], update[3], update[4])
                     end
                 else
@@ -395,8 +368,8 @@ If there are any problems, y]]
                     "Open log",
                     function()
                         alert({
-                            body = (heuristicError or "Y") .. [[
-ou can ask for help in the Celeste Discord server.
+                            body = [[
+You can ask for help in the Celeste Discord server.
 An invite can be found on the Everest website.
 
 Please drag and drop your files into the #modding_help channel.

--- a/src/scenes/installer.lua
+++ b/src/scenes/installer.lua
@@ -357,10 +357,11 @@ If that doesn't help, y]]
             {
                 "MonoModRules failed resolving Microsoft.Xna.Framework.Game",
                 [[
-Celeste needs to install some dependencies.
-Please run Celeste normally at least once before installing Everest.
+It is required to install XNA before installing Everest.
+If this copy of Celeste comes from Steam, run Celeste normally to install XNA.
+Otherwise, manually install XNA from https://www.microsoft.com/en-ca/download/details.aspx?id=20914.
 
-If that doesn't help, y]]
+If there are any problems, y]]
             }
         }
         repeat

--- a/src/scenes/installer.lua
+++ b/src/scenes/installer.lua
@@ -344,6 +344,25 @@ function scene.sharpTask(id, ...)
         local task = sharp[id](table.unpack(args)):result()
         local batch
         local last
+        local heuristicError
+        local heuristicErrors = {
+            {
+                "Unsupported version of Celeste:",
+                [[
+Your current version of Celeste is outdated.
+Please update to the latest version before installing Everest.
+
+If that doesn't help, y]]
+            },
+            {
+                "MonoModRules failed resolving Microsoft.Xna.Framework.Game",
+                [[
+Celeste needs to install some dependencies.
+Please run Celeste normally at least once before installing Everest.
+
+If that doesn't help, y]]
+            }
+        }
         repeat
             batch = sharp.pollWaitBatch(task):result()
             local all = batch[3]
@@ -352,6 +371,13 @@ function scene.sharpTask(id, ...)
                 if update ~= nil then
                     if not last or last[1] ~= update[1] or last[2] ~= update[2] or last[3] ~= update[3] or last[4] ~= update[4] then
                         last = update
+                        if not heuristicError then
+                            for j = 1, #heuristicErrors do
+                                if string.find(update[1], heuristicErrors[j][1]) ~= nil then
+                                    heuristicError = heuristicErrors[j][2]
+                                end
+                            end
+                        end
                         scene.update(update[1], update[2], update[3], update[4])
                     end
                 else
@@ -368,8 +394,8 @@ function scene.sharpTask(id, ...)
                     "Open log",
                     function()
                         alert({
-                            body = [[
-You can ask for help in the Celeste Discord server.
+                            body = (heuristicError or "Y") .. [[
+ou can ask for help in the Celeste Discord server.
 An invite can be found on the Everest website.
 
 Please drag and drop your files into the #modding_help channel.


### PR DESCRIPTION
Provides more detailed and user-friendly errors if the user is trying to install Everest on an out of data Celeste version or if they are using the XNA version of Celeste without XNA installed. This will hopefully help with the most common issues in #modding_help.
![image](https://user-images.githubusercontent.com/37253216/161124985-e8c2c367-d0d7-4b1d-872e-9f74d30feee1.png)
![image](https://user-images.githubusercontent.com/37253216/161124996-9f2044c2-d87a-4f06-918f-13b80bcf4b1b.png)
