### PR TITLE
Add support for .NET Core Everest builds

### DIFF
--- a/sharp/CmdGetVersionString.cs
+++ b/sharp/CmdGetVersionString.cs
@@ -32,7 +32,12 @@ namespace Olympus {
             }
 
             try {
-                using (ModuleDefinition game = ModuleDefinition.ReadModule(Path.Combine(root, "Celeste.exe"))) {
+                // Prefer Celeste.dll over Celeste.exe
+                string gamePath = Path.Combine(root, "Celeste.dll");
+                if (!File.Exists(gamePath))
+                    gamePath = Path.Combine(root, "Celeste.exe");
+
+                using (ModuleDefinition game = ModuleDefinition.ReadModule(gamePath)) {
                     TypeDefinition t_Celeste = game.GetType("Celeste.Celeste");
                     if (t_Celeste == null)
                         return new Tuple<string, Version, Version>("Not Celeste!", null, null);

--- a/sharp/CmdInstallEverest.MiniInstaller.cs
+++ b/sharp/CmdInstallEverest.MiniInstaller.cs
@@ -189,6 +189,14 @@ namespace Olympus {
                 if (!File.Exists(installerPath))
                     throw new Exception("Couldn't find MiniInstaller executable");
 
+                if (PlatformHelper.Is(Platform.Linux) || PlatformHelper.Is(Platform.MacOS)) {
+                    // Make MiniInstaller executable
+                    Process chmodProc = Process.Start(new ProcessStartInfo("chmod", $"u+x \"{installerPath}\""));
+                    chmodProc.WaitForExit();
+                    if (chmodProc.ExitCode != 0)
+                        throw new Exception("Failed to set MiniInstaller executable flag");
+                }
+                    
                 using (Process proc = new Process() { StartInfo = new ProcessStartInfo() {
                     FileName = installerPath,
                     UseShellExecute = false,

--- a/sharp/CmdInstallEverest.cs
+++ b/sharp/CmdInstallEverest.cs
@@ -31,8 +31,21 @@ namespace Olympus {
                 }
             }
 
-            bool isNative;
-            
+            bool isNativeInstall = File.Exists(Path.Combine(root, "Celeste.dll")), isNativeArtifact = false;
+
+            IEnumerator UnpackEverestArtifact(ZipArchive zip, string prefix = "") {
+                isNativeArtifact = CheckNativeMiniInstaller(zip, prefix);
+
+                // Legacy MiniInstaller builds can't correctly downgrade .NET Core installs
+                // Restore the install backup in this case
+                if (!isNativeArtifact && isNativeInstall) {
+                    yield return Status("Restoring non-modded backup", false, "", false);
+                    yield return Cmds.Get<CmdUninstallEverest>().Run(root, mainDownload);
+                }
+
+                yield return Unpack(zip, root, prefix);
+            }
+
             if (olympusBuildDownload.StartsWith("file://")) {
                 olympusBuildDownload = olympusBuildDownload.Substring("file://".Length);
                 yield return Status($"Unzipping {Path.GetFileName(olympusBuildDownload)}", false, "download", false);
@@ -40,15 +53,12 @@ namespace Olympus {
                 using (FileStream wrapStream = File.Open(olympusBuildDownload, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete))
                 using (ZipArchive wrap = new ZipArchive(wrapStream, ZipArchiveMode.Read)) {
                     ZipArchiveEntry zipEntry = wrap.GetEntry("olympus-build/build.zip");
-                    if (zipEntry == null) {
-                        isNative = CheckNativeMiniInstaller(wrap, "main/");
-                        yield return Unpack(wrap, root, "main/");
-                    } else {
+                    if (zipEntry == null)
+                        yield return UnpackEverestArtifact(wrap, "main/");
+                    else {
                         using (Stream zipStream = zipEntry.Open())
-                        using (ZipArchive zip = new ZipArchive(zipStream, ZipArchiveMode.Read)) {
-                            isNative = CheckNativeMiniInstaller(zip);
-                            yield return Unpack(zip, root);
-                        }
+                        using (ZipArchive zip = new ZipArchive(zipStream, ZipArchiveMode.Read))
+                            yield return UnpackEverestArtifact(zip);
                     }
                 }
 
@@ -83,10 +93,8 @@ namespace Olympus {
                         wrapStream.Seek(0, SeekOrigin.Begin);
                         using (ZipArchive wrap = new ZipArchive(wrapStream, ZipArchiveMode.Read)) {
                             using (Stream zipStream = wrap.GetEntry("olympus-build/build.zip").Open())
-                            using (ZipArchive zip = new ZipArchive(zipStream, ZipArchiveMode.Read)) {
-                                isNative = CheckNativeMiniInstaller(zip);
-                                yield return Unpack(zip, root);
-                            }
+                            using (ZipArchive zip = new ZipArchive(zipStream, ZipArchiveMode.Read))
+                                yield return UnpackEverestArtifact(zip);
                         }
                     }
 
@@ -98,43 +106,14 @@ namespace Olympus {
 
                         yield return Status("Unzipping main.zip", false, "download", false);
                         zipStream.Seek(0, SeekOrigin.Begin);
-                        using (ZipArchive zip = new ZipArchive(zipStream, ZipArchiveMode.Read)) {
-                            isNative = CheckNativeMiniInstaller(zip, "main/");
-                            yield return Unpack(zip, root, "main/");
-                        }
+                        using (ZipArchive zip = new ZipArchive(zipStream, ZipArchiveMode.Read))
+                            yield return UnpackEverestArtifact(zip, "main/");
                     }
                 }
-            }
-
-            // Legacy MiniInstaller builds can't correctly downgrade .NET Core installs
-            // Restore the install backup in this case
-            if (!isNative && File.Exists(Path.Combine(root, "Celeste.dll"))) {
-                yield return Status("Restoring non-modded backup", false, "", false);
-
-                foreach (string origEntry in Directory.EnumerateFileSystemEntries(Path.Combine(root, "orig"))) {
-                    // Ignore the Content folder - it is either a symlink or a 1-to-1 copy
-                    if (Path.GetFileName(origEntry) == "Content")
-                        continue;
-
-                    if (!File.Exists(origEntry) && !Directory.Exists(origEntry))
-                        continue;
-
-                    string gameEntry = Path.Combine(root, Path.GetFileName(origEntry));
-                    if (File.Exists(origEntry)) {
-                        File.Delete(gameEntry);
-                        File.Move(origEntry, gameEntry);
-                    } else if (Directory.Exists(gameEntry)) {
-                        Directory.Delete(gameEntry, true);
-                        Directory.Move(origEntry, gameEntry);
-                    }
-                }
-
-                Directory.Delete(Path.Combine(root, "orig"), true);
-                File.Delete(Path.Combine(root, "Celeste.dll")); // Explicitly delete Celeste.dll
             }
 
             yield return Status("Starting MiniInstaller", false, "monomod", false);
-            yield return Install(root, isNative);
+            yield return Install(root, isNativeArtifact);
         }
 
     }

--- a/sharp/CmdInstallEverest.cs
+++ b/sharp/CmdInstallEverest.cs
@@ -112,7 +112,7 @@ namespace Olympus {
                 }
             }
 
-            yield return Status("Starting MiniInstaller", false, "monomod", false);
+            yield return Status($"Starting {(isNativeArtifact ? "native" : "legacy")} MiniInstaller", false, "monomod", false);
             yield return Install(root, isNativeArtifact);
         }
 

--- a/sharp/CmdInstallEverest.cs
+++ b/sharp/CmdInstallEverest.cs
@@ -118,7 +118,7 @@ namespace Olympus {
                     if (!File.Exists(origEntry) && !Directory.Exists(origEntry))
                         continue;
 
-                    string gameEntry = Path.Combine(root, Path.GetRelativePath(Path.Combine(root, "orig"), origEntry));
+                    string gameEntry = Path.Combine(root, Path.GetFileName(origEntry));
                     if (File.Exists(origEntry)) {
                         File.Delete(gameEntry);
                         File.Move(origEntry, gameEntry);
@@ -128,7 +128,7 @@ namespace Olympus {
                     }
                 }
 
-                Directory.Delete(origDir, true);
+                Directory.Delete(Path.Combine(root, "orig"), true);
                 File.Delete(Path.Combine(root, "Celeste.dll")); // Explicitly delete Celeste.dll
             }
 

--- a/sharp/CmdUninstallEverest.cs
+++ b/sharp/CmdUninstallEverest.cs
@@ -22,7 +22,7 @@ namespace Olympus {
         private static readonly string[] OldEverestFileNames = new string[] {
             "apphosts", "everest-lib",
             "lib64-win-x64", "lib64-win-x86", "lib64-linux", "lib64-osx",
-            "Celeste.xml",
+            "Celeste.dll", "Celeste.xml",
             "Celeste.Mod.mm.dll", "Celeste.Mod.mm.pdb", "Celeste.Mod.mm.xml", "Celeste.Mod.mm.deps.json",
             "NETCoreifier.dll", "NETCoreifier.pdb", "NETCoreifier.deps.json",
             "MiniInstaller.exe", "MiniInstaller-win.exe", "MiniInstaller-linux", "MiniInstaller-osx", "MiniInstaller-win.exe.manifest",

--- a/sharp/CmdUninstallEverest.cs
+++ b/sharp/CmdUninstallEverest.cs
@@ -110,7 +110,7 @@ namespace Olympus {
                 if (File.Exists(path))
                     File.Delete(path);
                 else if (Directory.Exists(path))
-                    Directory.Delete(path);
+                    Directory.Delete(path, true);
             }
 
             foreach (string file in Directory.GetFiles(root)) {

--- a/sharp/CmdUninstallEverest.cs
+++ b/sharp/CmdUninstallEverest.cs
@@ -19,6 +19,16 @@ using System.Threading.Tasks;
 namespace Olympus {
     public unsafe class CmdUninstallEverest : Cmd<string, string, IEnumerator> {
 
+        private static readonly string[] OldEverestFileNames = new string[] {
+            "apphosts", "everest-lib",
+            "lib64-win-x64", "lib64-win-x86", "lib64-linux", "lib64-osx",
+            "Celeste.xml",
+            "Celeste.Mod.mm.dll", "Celeste.Mod.mm.pdb", "Celeste.Mod.mm.xml", "Celeste.Mod.mm.deps.json",
+            "NETCoreifier.dll", "NETCoreifier.pdb", "NETCoreifier.deps.json",
+            "MiniInstaller.exe", "MiniInstaller-win.exe", "MiniInstaller-linux", "MiniInstaller-osx", "MiniInstaller-win.exe.manifest",
+            "MiniInstaller.dll", "MiniInstaller.pdb", "MiniInstaller.runtimeconfig.json", "MiniInstaller.deps.json"
+        };
+
         public override IEnumerator Run(string root, string artifactBase) {
             yield return Status("Uninstalling Everest", false, "backup", false);
 
@@ -91,6 +101,23 @@ namespace Olympus {
             }
 
             yield return Status($"Reverted {revertEntries.Count} files", 1f, "done", true);
+
+            yield return Status($"Removing old Everest files", 0f, "backup", false);
+
+            foreach (string name in OldEverestFileNames) {
+                string path = Path.Combine(root, name);
+
+                if (File.Exists(path))
+                    File.Delete(path);
+                else if (Directory.Exists(path))
+                    Directory.Delete(path);
+            }
+
+            foreach (string file in Directory.GetFiles(root)) {
+                string ext = Path.GetExtension(file);
+                if(Path.GetFileName(file).StartsWith("MonoMod.") && (ext == ".dll" || ext == ".pdb" || ext == ".xml" || ext == ".json"))
+                    File.Delete(file);
+            }
         }
 
     }

--- a/sharp/CmdUninstallEverest.cs
+++ b/sharp/CmdUninstallEverest.cs
@@ -35,8 +35,8 @@ namespace Olympus {
             foreach (string orig in origs) {
                 string name = Path.GetFileName(orig);
                 
-                // Ignore the Content folder - it is either a symlink or a 1-to-1 copy
-                if (Path.GetFileName(orig) == "Content")
+                // Ignore the Content and Saves folder - it is either a symlink or a 1-to-1 copy
+                if (Path.GetFileName(orig) == "Content" || Path.GetFileName(orig) == "Saves")
                     continue;
 
                 // Ignore non-file/directory entries and symlinks

--- a/src/scenes/everest.lua
+++ b/src/scenes/everest.lua
@@ -73,9 +73,6 @@ Use the latest ]], { 0.3, 0.8, 0.5, 1 }, "stable", { 1, 1, 1, 1 }, " or ", { 0.8
             -- Check for any version before 1.4.0.0
             local minorVersion = install and install.versionCeleste and tonumber(install.versionCeleste:match("^1%.(%d+)%."))
 
-            local version = root:findChild("versions").selected
-            version = version and version.data
-            
             if install.versionCeleste == nil then
                 -- getting the version of Celeste failed, and the "version" is the error message that is displayed in the installation list.
                 local errorMessage = install.version
@@ -99,23 +96,6 @@ Use the latest ]], { 0.3, 0.8, 0.5, 1 }, "stable", { 1, 1, 1, 1 }, " or ", { 0.8
                     body = [[
 Your current version of Celeste is outdated.
 Please update to the latest version before installing Everest.]],
-                    buttons = {
-                        { "Attempt Installation Anyway", function(container)
-                            container:close("OK")
-                            scene.install()
-                        end },
-                        { "Cancel", function(container)
-                            container:close("OK")
-                        end }
-                    }
-                })
-            elseif love.system.getOS() == "Windows" and string.find(install.version, "xna") ~= nil and
-            version and version.sourceBranch and version.sourceBranch:gsub("refs/heads/", "") == "core" then
-                alert({
-                    body = [[
-.NET Core Everest builds only support FNA.
-If this copy of Celeste comes from Steam, switch to the opengl beta in the game properties.
-Otherwise, obtain an FNA build of the game from the place where you purchased it.]],
                     buttons = {
                         { "Attempt Installation Anyway", function(container)
                             container:close("OK")

--- a/src/scenes/everest.lua
+++ b/src/scenes/everest.lua
@@ -323,7 +323,7 @@ function scene.load()
 
         if url then
             url = utils.trim(url)
-            if string:match(url, "?") then url = url .. "&" else url = url .. "?" end
+            if string.match(url, "?") then url = url .. "&" else url = url .. "?" end
             url = url .. "supportsNativeBuilds=true"
 
             buildsTask = utilsAsync.downloadJSON(url)

--- a/src/scenes/everest.lua
+++ b/src/scenes/everest.lua
@@ -318,7 +318,7 @@ function scene.load()
 
     threader.routine(function()
         local utilsAsync = threader.wrap("utils")
-        local buildsTask = utilsAsync.download("https://everestapi.github.io/everestupdater.txt")
+        local buildsTask = utilsAsync.download("https://everestapi.github.io/everestupdater.txt?supportsNativeBuilds=true")
         local url, buildsError = buildsTask:result()
 
         if url then

--- a/src/scenes/everest.lua
+++ b/src/scenes/everest.lua
@@ -322,8 +322,11 @@ function scene.load()
         local url, buildsError = buildsTask:result()
 
         if url then
-            url = url + (url:match("?") and "&" or "?") + "supportsNativeBuilds=true"
-            buildsTask = utilsAsync.downloadJSON(utils.trim(url))
+            url = utils.trim(url)
+            if string:match(url, "?") then url = url + "&" else url = url + "?" end
+            url = url + "supportsNativeBuilds=true"
+
+            buildsTask = utilsAsync.downloadJSON(url)
         end
 
         local list = root:findChild("versions")

--- a/src/scenes/everest.lua
+++ b/src/scenes/everest.lua
@@ -318,10 +318,11 @@ function scene.load()
 
     threader.routine(function()
         local utilsAsync = threader.wrap("utils")
-        local buildsTask = utilsAsync.download("https://everestapi.github.io/everestupdater.txt?supportsNativeBuilds=true")
+        local buildsTask = utilsAsync.download("https://everestapi.github.io/everestupdater.txt")
         local url, buildsError = buildsTask:result()
 
         if url then
+            url = url + (url:match("?") and "&" or "?") + "supportsNativeBuilds=true"
             buildsTask = utilsAsync.downloadJSON(utils.trim(url))
         end
 

--- a/src/scenes/everest.lua
+++ b/src/scenes/everest.lua
@@ -323,8 +323,8 @@ function scene.load()
 
         if url then
             url = utils.trim(url)
-            if string:match(url, "?") then url = url + "&" else url = url + "?" end
-            url = url + "supportsNativeBuilds=true"
+            if string:match(url, "?") then url = url .. "&" else url = url .. "?" end
+            url = url .. "supportsNativeBuilds=true"
 
             buildsTask = utilsAsync.downloadJSON(url)
         end

--- a/src/scenes/everest.lua
+++ b/src/scenes/everest.lua
@@ -73,6 +73,9 @@ Use the latest ]], { 0.3, 0.8, 0.5, 1 }, "stable", { 1, 1, 1, 1 }, " or ", { 0.8
             -- Check for any version before 1.4.0.0
             local minorVersion = install and install.versionCeleste and tonumber(install.versionCeleste:match("^1%.(%d+)%."))
 
+            local version = root:findChild("versions").selected
+            version = version and version.data
+            
             if install.versionCeleste == nil then
                 -- getting the version of Celeste failed, and the "version" is the error message that is displayed in the installation list.
                 local errorMessage = install.version
@@ -96,6 +99,23 @@ Use the latest ]], { 0.3, 0.8, 0.5, 1 }, "stable", { 1, 1, 1, 1 }, " or ", { 0.8
                     body = [[
 Your current version of Celeste is outdated.
 Please update to the latest version before installing Everest.]],
+                    buttons = {
+                        { "Attempt Installation Anyway", function(container)
+                            container:close("OK")
+                            scene.install()
+                        end },
+                        { "Cancel", function(container)
+                            container:close("OK")
+                        end }
+                    }
+                })
+            elseif love.system.getOS() == "Windows" and string.find(install.version, "xna") ~= nil and
+            version and version.sourceBranch and version.sourceBranch:gsub("refs/heads/", "") == "core" then
+                alert({
+                    body = [[
+.NET Core Everest builds only support FNA.
+If this copy of Celeste comes from Steam, switch to the opengl beta in the game properties.
+Otherwise, obtain an FNA build of the game from the place where you purchased it.]],
                     buttons = {
                         { "Attempt Installation Anyway", function(container)
                             container:close("OK")


### PR DESCRIPTION
This change adds support for running native MiniInstaller binaries as part of the update process, in preparation for a potential modern .NET version in the future.