### PR TITLE
Downgrade Ubuntu on pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ strategy:
       launcher: ''
     linux:
       jobArchName: 'linux'
-      imageName: 'ubuntu-latest'
+      imageName: 'ubuntu-20.04'
       agentArch: 'linux'
       artifactPrefix: 'linux.'
       artifactSuffix: ''

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,4 +3,4 @@ and only contains the latest changes.
 Its purpose is to be shown in Olympus when updating.
 
 #changelog#
-∙ The Everest version list now comes from the same API as used by Everest
+∙ The Linux version of Olympus is now built on Ubuntu 20.04, to (hopefully) fix glibc-related errors on some distributions


### PR DESCRIPTION
Older Ubuntu used an older glibc, which should hopefully fix issues people are having with outdated Linux versions, or Linux distributions that are behind on glibc (like Debian).

Going through a PR to run the pipeline and check that it works.