### PR TITLE
Avoid unnecessary luajit-request not loaded error

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,4 +3,4 @@ and only contains the latest changes.
 Its purpose is to be shown in Olympus when updating.
 
 #changelog#
-∙ The Linux version of Olympus is now built on Ubuntu 20.04, to (hopefully) fix glibc-related errors on some distributions
+∙ Fixed some unnecessary "luajit-request not loaded" errors

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -147,13 +147,13 @@ function utils.download(url, headers)
         return false, 0, data
     end
 
-    headers = headers or {
+    local headersToUse = headers or {
         ["User-Agent"] = "curl/7.64.1",
         ["Accept"] = "*/*"
     }
 
     local response, error = request.send(url, {
-        headers = headers
+        headers = headersToUse
     })
 
     local body, code


### PR DESCRIPTION
(going through a PR to be able to merge from mobile)

Olympus.Sharp does not handle headers, and when retrying after libcurl failed, there are some headers put there by default, so it will necessarily fail even if the caller didn't ask for headers to be sent 😅