### PR TITLE
Prefer system wide installs for love on linux (and macOS)

### DIFF
--- a/olympus.sh
+++ b/olympus.sh
@@ -29,12 +29,46 @@ else
     export LD_LIBRARY_PATH
 fi
 
+# Order priority goes as follows:
+# 1. love if its not too old, if too old or missing then
+# 2. bundled love, if missing then
+# 3. love even tho we know its old, if missing then
+# 4. love2d is always too old, but it is used as a last resource, if missing just cry
+
+if command -v love >/dev/null 2>&1; then
+	# Get installed love version
+	LOVE_VER=$(love --version | awk '{split($0,ver," "); print ver[2]}')
+	LOVE_VER_MAJ=$(echo $LOVE_VER | awk '{split($0,mver,"."); print mver[1]}')
+	LOVE_VER_MIN=$(echo $LOVE_VER | awk '{split($0,mver,"."); print mver[2]}')
+	
+	# Get bundled love version
+	if [ -f "love" ]; then
+		BUN_LOVE_VER=$(./love --version | awk '{split($0,ver," "); print ver[2]}')
+		BUN_LOVE_VER_MAJ=$(echo $BUN_LOVE_VER | awk '{split($0,mver,"."); print mver[1]}')
+		BUN_LOVE_VER_MIN=$(echo $BUN_LOVE_VER | awk '{split($0,mver,"."); print mver[2]}')
+		# Compare versions
+		if [ $LOVE_VER_MAJ -gt $BUN_LOVE_VER_MAJ ] || 
+			([ $LOVE_VER_MAJ -eq $BUN_LOVE_VER_MAJ ] && [ $LOVE_VER_MIN -ge $BUN_LOVE_VER_MIN ]); then
+			echo "Using system wide love installation"
+			love --fused olympus.love $@ # Go with it
+			exit
+		fi # Too old, check other options
+	else # if no bundled love, just use it
+		echo "Using system wide love installation, unknown target version"
+		love --fused olympus.love $@
+		exit
+	fi
+fi
 if [ -f "love" ]; then
+	echo "Using bundled love"
     ./love --fused olympus.love $@
-elif command -v love >/dev/null 2>&1; then
-    love --fused olympus.love $@
+elif command -v love >/dev/null 2>&1; then # We know it is old, but go for it anyway
+	echo "Using oudated system wide love installation"
+	love --fused olympus.love $@
 elif command -v love2d >/dev/null 2>&1; then
+	echo "Using love2d, trouble incoming (hopefully not)"
     love2d --fused olympus.love $@
 else
     echo "love2d not found!"
 fi
+


### PR DESCRIPTION
This partially fixes #48 if love is installed system wide.

The new logic is explained in the code. Basically prefers system wide installations of love if version is enough.
This is an improvement because if it comes from distro repositories it is guaranteed to work fine.

NOT TESTED ON MACOS. But since all is generic unix stuff it *should* work.