### PR TITLE
Set macOS arch to x86_64 to avoid M1 crash

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -376,6 +376,8 @@ steps:
       rm $PLIST
       mv love/$LOVEBINARYDIRECTORY/Info.plist $PLIST
       plutil -replace CFBundleShortVersionString -string "$BUILD_BUILDNUMBER" $PLIST
+      plutil -insert LSArchitecturePriority -array $PLIST
+      plutil -insert LSArchitecturePriority -string x86_64 -append $PLIST
       curl https://www.libsdl.org/release/SDL2-2.0.14.dmg -o sdl2.dmg
       hdiutil attach -mountpoint sdl2mount sdl2.dmg
       rm -rf love/love.app/Contents/Frameworks/SDL2.framework


### PR DESCRIPTION
Fix proposed in https://github.com/EverestAPI/Olympus/issues/65

Sets default macos arch to x86_64 in .plist so that Olympus isn't misidentified as arm64 which results in crashes on M1 Macs