### PR TITLE
Fix #71, make loenn search for good love binaries too

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -391,6 +391,8 @@ steps:
       cp -f luajit-2.0/src/libluajit.so love/love.app/Contents/Frameworks/Lua.framework/Versions/A/Lua
       cp olympus.sh love/$LOVEBINARYDIRECTORY/olympus.sh
       chmod a+rx love/$LOVEBINARYDIRECTORY/olympus.sh
+      cp find-love.sh love/$LOVEBINARYDIRECTORY/find-love
+      chmod a+rx love/$LOVEBINARYDIRECTORY/find-love
       chmod a+rx love/$LOVEBINARYDIRECTORY/love
       chmod a+rx love/$LOVEBINARYDIRECTORY/sharp/Olympus.Sharp.bin*
       codesign --remove-signature love/$LOVEBINARYDIRECTORY/love
@@ -409,6 +411,8 @@ steps:
     script: |
       cp olympus.sh love/$LOVEBINARYDIRECTORY/olympus
       chmod a+rx love/$LOVEBINARYDIRECTORY/olympus
+      cp find-love.sh love/$LOVEBINARYDIRECTORY/find-love
+      chmod a+rx love/$LOVEBINARYDIRECTORY/find-love
       chmod a+rx love/$LOVEBINARYDIRECTORY/love
       chmod a+rx love/$LOVEBINARYDIRECTORY/install.sh
       chmod a+rx love/$LOVEBINARYDIRECTORY/sharp/Olympus.Sharp.bin*

--- a/find-love.sh
+++ b/find-love.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+# A linux-only script for running a love file using the correct engine binary
+# This script's working directory must be the bundled love's one and it'll set 
+# everything up by itself
+
+BUN_LOVE_DIR="$(pwd)/love"
+
+# Order priority goes as follows:
+# 1. love if its not too old, if too old or missing then
+# 2. bundled love, if missing then
+# 3. love even tho we know its old, if missing then
+# 4. love2d is always too old, but it is used as a last resource, if missing just cry
+
+if command -v love >/dev/null 2>&1; then
+    # Get installed love version
+    LOVE_VER=$(love --version | awk '{split($0,ver," "); print ver[2]}')
+    LOVE_VER_MAJ=$(echo $LOVE_VER | awk '{split($0,mver,"."); print mver[1]}')
+    LOVE_VER_MIN=$(echo $LOVE_VER | awk '{split($0,mver,"."); print mver[2]}')
+
+    # Get bundled love version
+    if [ -f "love" ]; then
+        BUN_LOVE_VER=$(./love --version | awk '{split($0,ver," "); print ver[2]}')
+        BUN_LOVE_VER_MAJ=$(echo $BUN_LOVE_VER | awk '{split($0,mver,"."); print mver[1]}')
+        BUN_LOVE_VER_MIN=$(echo $BUN_LOVE_VER | awk '{split($0,mver,"."); print mver[2]}')
+        # Compare versions
+        if [ $LOVE_VER_MAJ -gt $BUN_LOVE_VER_MAJ ] ||
+            ([ $LOVE_VER_MAJ -eq $BUN_LOVE_VER_MAJ ] && [ $LOVE_VER_MIN -ge $BUN_LOVE_VER_MIN ]); then
+		    cd $(dirname $1)
+            echo "Using system wide love installation"
+            love --fused $@ # Go with it
+            exit
+        fi # Too old, check other options
+    else # if no bundled love, just use it
+        echo "Using system wide love installation, unknown target version"
+		cd $(dirname $1)
+        love --fused $@
+        exit
+    fi
+fi
+if [ -f "love" ]; then
+    echo "Using bundled love"
+	cd $(dirname $1)
+    "$BUN_LOVE_DIR"/love --fused $@
+elif command -v love >/dev/null 2>&1; then # We know it is old, but go for it anyway
+    echo "Using oudated system wide love installation"
+	cd $(dirname $1)
+    love --fused $@
+elif command -v love2d >/dev/null 2>&1; then
+    echo "Using love2d, trouble incoming (hopefully not)"
+	cd $(dirname $1)
+    love2d --fused $@
+else
+    echo "love2d not found!"
+	exit 1
+fi
+

--- a/olympus.sh
+++ b/olympus.sh
@@ -29,46 +29,13 @@ else
     export LD_LIBRARY_PATH
 fi
 
-# Order priority goes as follows:
-# 1. love if its not too old, if too old or missing then
-# 2. bundled love, if missing then
-# 3. love even tho we know its old, if missing then
-# 4. love2d is always too old, but it is used as a last resource, if missing just cry
-
-if command -v love >/dev/null 2>&1; then
-    # Get installed love version
-    LOVE_VER=$(love --version | awk '{split($0,ver," "); print ver[2]}')
-    LOVE_VER_MAJ=$(echo $LOVE_VER | awk '{split($0,mver,"."); print mver[1]}')
-    LOVE_VER_MIN=$(echo $LOVE_VER | awk '{split($0,mver,"."); print mver[2]}')
-
-    # Get bundled love version
-    if [ -f "love" ]; then
-        BUN_LOVE_VER=$(./love --version | awk '{split($0,ver," "); print ver[2]}')
-        BUN_LOVE_VER_MAJ=$(echo $BUN_LOVE_VER | awk '{split($0,mver,"."); print mver[1]}')
-        BUN_LOVE_VER_MIN=$(echo $BUN_LOVE_VER | awk '{split($0,mver,"."); print mver[2]}')
-        # Compare versions
-        if [ $LOVE_VER_MAJ -gt $BUN_LOVE_VER_MAJ ] ||
-            ([ $LOVE_VER_MAJ -eq $BUN_LOVE_VER_MAJ ] && [ $LOVE_VER_MIN -ge $BUN_LOVE_VER_MIN ]); then
-            echo "Using system wide love installation"
-            love --fused olympus.love $@ # Go with it
-            exit
-        fi # Too old, check other options
-    else # if no bundled love, just use it
-        echo "Using system wide love installation, unknown target version"
-        love --fused olympus.love $@
-        exit
-    fi
-fi
-if [ -f "love" ]; then
-    echo "Using bundled love"
-    ./love --fused olympus.love $@
-elif command -v love >/dev/null 2>&1; then # We know it is old, but go for it anyway
-    echo "Using oudated system wide love installation"
-    love --fused olympus.love $@
-elif command -v love2d >/dev/null 2>&1; then
-    echo "Using love2d, trouble incoming (hopefully not)"
-    love2d --fused olympus.love $@
+# On Linux/osx we use the wrapper script, the .sh version is here for debugging purposes
+if [ -f "find-love.sh" ]; then
+	./find-love.sh olympus.love
+elif [ -f "find-love" ]; then
+	./find-love olympus.love
 else
-    echo "love2d not found!"
+	echo "find-love script not found, can't proceed!"
+	exit 1
 fi
 

--- a/sharp/CmdLaunchLoenn.cs
+++ b/sharp/CmdLaunchLoenn.cs
@@ -13,19 +13,21 @@ namespace Olympus {
 
             if (PlatformHelper.Is(Platform.Windows)) {
                 loenn.StartInfo.FileName = Path.Combine(root, "Lönn.exe");
+				loenn.StartInfo.WorkingDirectory = root;
             } else if (PlatformHelper.Is(Platform.Linux)) {
-                // use Olympus's own love2d
-                loenn.StartInfo.FileName = Path.Combine(Program.RootDirectory, "love");
-                loenn.StartInfo.Arguments = "Lönn.love";
+                // use the find-love script that olympus also uses
+                loenn.StartInfo.FileName = Path.Combine(Program.RootDirectory, "find-love");
+                loenn.StartInfo.Arguments = Path.Combine(root, "Lönn.love");
                 loenn.StartInfo.UseShellExecute = true;
+				loenn.StartInfo.WorkingDirectory = Program.RootDirectory;
             } else {
                 // run the app
                 loenn.StartInfo.FileName = "open";
                 loenn.StartInfo.Arguments = "Lönn.app";
                 loenn.StartInfo.UseShellExecute = true;
+				loenn.StartInfo.WorkingDirectory = root;
             }
 
-            loenn.StartInfo.WorkingDirectory = root;
 
             Console.Error.WriteLine($"Starting Loenn process: {loenn.StartInfo.FileName} {loenn.StartInfo.Arguments} (in {root})");
 

--- a/sharp/CmdLaunchLoenn.cs
+++ b/sharp/CmdLaunchLoenn.cs
@@ -13,7 +13,7 @@ namespace Olympus {
 
             if (PlatformHelper.Is(Platform.Windows)) {
                 loenn.StartInfo.FileName = Path.Combine(root, "Lönn.exe");
-				loenn.StartInfo.WorkingDirectory = root;
+                loenn.StartInfo.WorkingDirectory = root;
             } else if (PlatformHelper.Is(Platform.Linux)) {
                 // use the find-love script that olympus also uses
                 loenn.StartInfo.FileName = Path.Combine(Program.RootDirectory, "find-love");

--- a/sharp/CmdLaunchLoenn.cs
+++ b/sharp/CmdLaunchLoenn.cs
@@ -19,13 +19,13 @@ namespace Olympus {
                 loenn.StartInfo.FileName = Path.Combine(Program.RootDirectory, "find-love");
                 loenn.StartInfo.Arguments = Path.Combine(root, "Lönn.love");
                 loenn.StartInfo.UseShellExecute = true;
-				loenn.StartInfo.WorkingDirectory = Program.RootDirectory;
+                loenn.StartInfo.WorkingDirectory = Program.RootDirectory;
             } else {
                 // run the app
                 loenn.StartInfo.FileName = "open";
                 loenn.StartInfo.Arguments = "Lönn.app";
                 loenn.StartInfo.UseShellExecute = true;
-				loenn.StartInfo.WorkingDirectory = root;
+                loenn.StartInfo.WorkingDirectory = root;
             }
 
 


### PR DESCRIPTION
Fixes #71, introduced by #63. Makes sure that loenn will also find a good love binary to run on linux and not always defaults to the bundled, even if missing.
The `find-love.sh` script can be used on macos, but that platform already uses an all-in-one file so its pointless.
The only place where this is broken right now its on the AUR, since there it strips binaries like the bundled love
