### PR TITLE
[Linux] Add the ground work for the future flatpak package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -411,6 +411,8 @@ steps:
     script: |
       cp olympus.sh love/$LOVEBINARYDIRECTORY/olympus
       chmod a+rx love/$LOVEBINARYDIRECTORY/olympus
+      cp flatpak-wrapper.sh love/$LOVEBINARYDIRECTORY/flatpak-wrapper
+      chmod a+rx love/$LOVEBINARYDIRECTORY/flatpak-wrapper
       cp find-love.sh love/$LOVEBINARYDIRECTORY/find-love
       chmod a+rx love/$LOVEBINARYDIRECTORY/find-love
       chmod a+rx love/$LOVEBINARYDIRECTORY/love

--- a/flatpak-wrapper.sh
+++ b/flatpak-wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+#
+# A linux-only script that allows the flatpak version of Olympus to be able to start Celeste
+exec flatpak-spawn --host $@

--- a/sharp/CmdLaunch.cs
+++ b/sharp/CmdLaunch.cs
@@ -64,6 +64,17 @@ namespace Olympus {
 
             if (!string.IsNullOrEmpty(args))
                 game.StartInfo.Arguments = args;
+        
+            // Flatpak detection
+            // or string.Equals(Environment.GetEnvironmentVariable("container"), "flatpak");
+            if (File.Exists("/.flatpak-info")) {
+            	if (!string.IsNullOrEmpty(args))
+                    game.StartInfo.Arguments = string.Join(" ", game.StartInfo.FileName, args);
+                else
+                    game.StartInfo.Arguments = game.StartInfo.FileName;
+                game.StartInfo.FileName = Path.Combine(Program.RootDirectory, "flatpak-wrapper");
+                game.StartInfo.UseShellExecute = true;
+            }
 
             Console.Error.WriteLine($"Starting Celeste process: {game.StartInfo.FileName} {(string.IsNullOrEmpty(args) ? "(without args)" : args)}");
 

--- a/src/finder.lua
+++ b/src/finder.lua
@@ -25,6 +25,14 @@ finder.defaultName = "Celeste"
 -- https://bspmts.mp.microsoft.com/v1/public/catalog/Retail/Products/bwmql2rpwbhb/applockerdata
 finder.defaultUWPName = "MattMakesGamesInc.Celeste_79daxvg0dq3v6"
 
+-- enhance linux compatibility 
+local function getLinuxConfigDir()
+    local xdg_cfg = os.getenv("XDG_CONFIG_HOME")
+    if fs.isFile("/.flatpak-info") or xdg == "" then
+       return fs.joinpath(os.getenv("HOME"), ".config")
+    end
+    return xdg_cfg
+end
 
 function finder.findSteamRoot()
     local userOS = love.system.getOS()
@@ -302,7 +310,7 @@ function finder.findLegendaryRoot()
 
     -- As of the time of writing this, Legendary is only supported for Windows and Linux.
     -- It follows XDG_CONFIG_HOME and ~/.config/legendary on all platforms.
-    local root = fs.joinpath(os.getenv("XDG_CONFIG_HOME") or fs.joinpath(userOS == "Windows" and sharp.getEnv("USERPROFILE"):result() or os.getenv("HOME"), ".config"), "legendary")
+    local root = fs.joinpath(getLinuxConfigDir() or fs.joinpath(userOS == "Windows" and sharp.getEnv("USERPROFILE"):result(), ".config"), "legendary")
 
     if root then
         local rootReal = fs.isDirectory(root)
@@ -357,7 +365,7 @@ function finder.findItchDatabase()
         db = fs.joinpath(os.getenv("HOME"), "Library", "Application Support", "itch", "db", "butler.db")
 
     elseif userOS == "Linux" then
-        db = fs.joinpath(os.getenv("XDG_CONFIG_HOME") or fs.joinpath(os.getenv("HOME"), ".config"), "itch", "db", "butler.db")
+        db = fs.joinpath(getLinuxConfigDir(), "itch", "db", "butler.db")
     end
 
     if db then
@@ -465,7 +473,7 @@ function finder.findLutrisRoot()
     local root
 
     if userOS == "Linux" then
-        root = fs.joinpath(os.getenv("XDG_CONFIG_HOME") or fs.joinpath(os.getenv("HOME"), ".config"), "lutris")
+        root = fs.joinpath(getLinuxConfigDir(), "lutris")
     end
 
     if root then

--- a/src/finder.lua
+++ b/src/finder.lua
@@ -54,6 +54,7 @@ function finder.findSteamRoot()
             fs.joinpath(os.getenv("HOME"), ".steam", "steam"),
             fs.joinpath(os.getenv("HOME"), ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam"),
             fs.joinpath(os.getenv("HOME"), ".var", "app", "com.valvesoftware.Steam", ".steam", "steam"),
+            fs.joinpath("/run", "media", "mmcblk0p1"), -- Add Steam Deck micro SD folder
         }
 
         for i = 1, #paths do

--- a/src/finder.lua
+++ b/src/finder.lua
@@ -28,7 +28,7 @@ finder.defaultUWPName = "MattMakesGamesInc.Celeste_79daxvg0dq3v6"
 -- enhance linux compatibility 
 local function getLinuxConfigDir()
     local xdg_cfg = os.getenv("XDG_CONFIG_HOME")
-    if fs.isFile("/.flatpak-info") or xdg == "" then
+    if fs.isFile("/.flatpak-info") or xdg_cfg == "" then
        return fs.joinpath(os.getenv("HOME"), ".config")
     end
     return xdg_cfg


### PR DESCRIPTION
This PR adds the base needed for the future Olympus flatpak package to work out-of-the-box like the official linux installation process.
This adds : 
- `flatpak-spawn --host` support in order to launch Celeste normally from Olympus
- Enhance `finder.lua` so it searches Celeste installations in the right folders
- Misc: Support automatic detection of Celeste installations on the Steam Deck micro SD

Special thanks to @Wartori54 for the help !
Another PR will follow to fix the `extra-data` download and after all of this I will submit the flatpak on flathub. 

Linked with #12 