### PR TITLE
[Linux] Fix 1 click-installs

### DIFF
--- a/olympus.sh
+++ b/olympus.sh
@@ -31,9 +31,9 @@ fi
 
 # On Linux/osx we use the wrapper script, the .sh version is here for debugging purposes
 if [ -f "find-love.sh" ]; then
-	./find-love.sh olympus.love
+	./find-love.sh olympus.love $@
 elif [ -f "find-love" ]; then
-	./find-love olympus.love
+	./find-love olympus.love $@
 else
 	echo "find-love script not found, can't proceed!"
 	exit 1


### PR DESCRIPTION
The everest mod url was dropped when launching `olympus.love` inside `olympus.sh` thus 1 click installs couldn't work.