### PR TITLE
Linux/Flatpak: Prevent update prompt under flatpak

### DIFF
--- a/src/updater.lua
+++ b/src/updater.lua
@@ -27,6 +27,11 @@ if userOS == "Linux" then
     else
         updater.available = false
     end
+    
+    -- Override: if it's the Olympus flatpak we let flatpak handle the updates
+    if fs.isFile("/.flatpak-info") then
+        updater.available = false
+    end
 
 else
     updater.available = true


### PR DESCRIPTION
This PR improves the flatpak package by preventing the autoupdater prompt since flatpak already handled the updates.