### PR TITLE
Use `CreateNoWindow = true` for native MiniInstaller processes

### DIFF
--- a/sharp/CmdInstallEverest.MiniInstaller.cs
+++ b/sharp/CmdInstallEverest.MiniInstaller.cs
@@ -203,7 +203,8 @@ namespace Olympus {
                     UseShellExecute = false,
                     RedirectStandardInput = true,
                     RedirectStandardOutput = true,
-                    RedirectStandardError = true
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
                 }}) {
                     proc.OutputDataReceived += (o, e) => bridge.WriteLine(e.Data);
                     proc.ErrorDataReceived += (o, e) => bridge.WriteLine(e.Data);


### PR DESCRIPTION
The title explains it. This causes Olympus to not spawn a empty console window when running MiniInstaller. I have not tested this in Olympus, but [it did work](https://github.com/Wartori54/Olympus.FNA/blob/dc7fd1255c7029aa9ddd9d6049b81f330a22cd3b/Olympus.FNA/Utils/EverestInstaller.cs#L474) while working with Olympus.FNA.
Though Olympus.FNA runs on .net core 7 and Olympus.Sharp in .net framework 4.5.2, which could cause this patch to not work.