### PR TITLE
feat(linux): Support steam flatpak

### DIFF
--- a/sharp/CmdLaunch.cs
+++ b/sharp/CmdLaunch.cs
@@ -62,6 +62,15 @@ namespace Olympus {
                 }
             }
 
+            // Steam flatpak detection
+            // Default game path: /home/USER/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/Celeste
+            if (Environment.OSVersion.Platform == PlatformID.Unix && game.StartInfo.FileName.Contains("com.valvesoftware.Steam")) {
+                game.StartInfo.FileName = "xdg-open";
+                args = "steam://run/504230";
+                game.StartInfo.UseShellExecute = true;
+                // args won't work but launch vanilla will work because it uses nextLaunchIsVanilla.txt
+            }
+
             if (!string.IsNullOrEmpty(args))
                 game.StartInfo.Arguments = args;
 


### PR DESCRIPTION
Currently, Olympus simply takes Celeste game path and try to launch it. 
However, when the game is used within the steam flatpak runtime, this usual handling is not enough for Celeste to use/detect the steam installation properly, thus the game can't be launched and needs to be launched within steam.

This PR adds basic support by using the steam url handler. Launching Celeste within the steam flatpak is then as simple as `xdg-open steam://run/504230`. 

Note: The `steam://` url handler is automatically installed when users installs the steam flatpak from Flathub.