### PR TITLE
"Fix" cursed Windows issues by downgrading LuaJIT

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ strategy:
       netbuilder: 'core'
       lualibs: 'prebuilt'
       loveURL: 'https://github.com/love2d/love/releases/download/11.5/love-11.5-win32.zip'
+      loveLuaURL: 'https://github.com/love2d/love/releases/download/11.3/love-11.3-win32.zip'
       loveZIP: 'love.zip'
       loveAppImage: ''
       loveBinaryDirectory: ''
@@ -27,6 +28,7 @@ strategy:
       luarocksPreArgs: '--lua-dir=/usr/local/opt/lua@5.1'
       luarocksArgs: 'LUA_LIBDIR="/usr/local/opt/lua@5.1/lib"'
       loveURL: 'https://github.com/love2d/love/releases/download/11.5/love-11.5-macos.zip'
+      loveLuaURL: ''
       loveZIP: 'love.zip'
       loveAppImage: ''
       loveBinaryDirectory: 'love.app/Contents/MacOS/'
@@ -43,6 +45,7 @@ strategy:
       lualibs: 'luarocks'
       luarocksArgs: 'LUA_LIBDIR="/usr/local/opt/lua/lib"'
       loveURL: 'https://github.com/love2d/love/releases/download/11.5/love-11.5-x86_64.AppImage'
+      loveLuaURL: ''
       loveZIP: ''
       loveAppImage: 'love-raw/love'
       loveBinaryDirectory: ''
@@ -186,7 +189,7 @@ steps:
   condition: and(succeeded(), ne(variables.loveURL, ''))
   displayName: 'Dist: Grab cached LÖVE'
   inputs:
-    key: 'love-unpacked-11-4 | "$(Agent.OS)"'
+    key: 'love-unpacked-11-5 | "$(Agent.OS)"'
     path: love-raw
     cacheHitVar: loveCached
 - task: PowerShell@2
@@ -206,6 +209,17 @@ steps:
     targetType: 'inline'
     script: |
       Expand-Archive -Path $env:LOVEZIP -DestinationPath love-raw
+# If we need to pull lua51.dll from another LÖVE package, download, unzip and grab lua51.dll.
+- task: PowerShell@2
+  condition: and(succeeded(), ne(variables.loveLuaZIP, ''), ne(variables.loveCached, 'true'))
+  displayName: 'Dist: Replace lua51.dll'
+  continueOnError: true
+  inputs:
+    targetType: 'inline'
+    script: |
+      Invoke-WebRequest -Uri $env:LOVELUAZIP -OutFile lovelua.zip
+      Expand-Archive -Path lovelua.zip -DestinationPath lovelua
+      Copy-Item -Path lovelua/love-11.3-win32/lua51.dll -Destination love-raw/love-11.5-win32/lua51.dll -Force
 # Copy cached unpacked LÖVE, fix it up if needed
 - task: PowerShell@2
   condition: and(succeeded(), ne(variables.loveURL, ''))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,7 +217,7 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      Invoke-WebRequest -Uri $env:LOVELUAZIP -OutFile lovelua.zip
+      Invoke-WebRequest -Uri $env:LOVELUAURL -OutFile lovelua.zip
       Expand-Archive -Path lovelua.zip -DestinationPath lovelua
       Copy-Item -Path lovelua/love-11.3-win32/lua51.dll -Destination love-raw/love-11.5-win32/lua51.dll -Force
 # Copy cached unpacked LÖVE, fix it up if needed

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -189,7 +189,7 @@ steps:
   condition: and(succeeded(), ne(variables.loveURL, ''))
   displayName: 'Dist: Grab cached LÖVE'
   inputs:
-    key: 'love-unpacked-11-5 | "$(Agent.OS)"'
+    key: 'love-unpacked | "$(Agent.OS)"'
     path: love-raw
     cacheHitVar: loveCached
 - task: PowerShell@2
@@ -211,7 +211,7 @@ steps:
       Expand-Archive -Path $env:LOVEZIP -DestinationPath love-raw
 # If we need to pull lua51.dll from another LÖVE package, download, unzip and grab lua51.dll.
 - task: PowerShell@2
-  condition: and(succeeded(), ne(variables.loveLuaZIP, ''), ne(variables.loveCached, 'true'))
+  condition: and(succeeded(), ne(variables.loveLuaURL, ''), ne(variables.loveCached, 'true'))
   displayName: 'Dist: Replace lua51.dll'
   continueOnError: true
   inputs:

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,5 +3,4 @@ and only contains the latest changes.
 Its purpose is to be shown in Olympus when updating.
 
 #changelog#
-∙ Added some environment variables to control Olympus behavior, for use in the NixOS package
-∙ Disable unused love2d features (audio, joystick, physics, touch, video), which should prevent Olympus from appearing in sound sources
+∙ Downgrade LuaJIT from 2.1 to 2.0 on Windows to (hopefully) fix Olympus randomly closing on some machines


### PR DESCRIPTION
Updating love2d from 11.3 to 11.4 also updates LuaJIT from 2.0 to 2.1, and it seems that this is a cause of mysterious segfaults when moving the mouse around the Ahorn install screen, installing Everest, and just anywhere else. So here we go: crusty workaround!