### PR TITLE
random untrimmed build jumpscare

### DIFF
--- a/sharp/Olympus.Sharp.csproj
+++ b/sharp/Olympus.Sharp.csproj
@@ -7,7 +7,7 @@
     <ApplicationIcon />
     <StartupObject />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PublishTrimmed>true</PublishTrimmed>
+    <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('win'))">


### PR DESCRIPTION
Triggers an Azure pipeline build that turns off trimming, in order to check if that makes errors clearer for people that run into issues in #modding_help