### PR TITLE
Disable autoupdater for the flatpak

### DIFF
--- a/src/updater.lua
+++ b/src/updater.lua
@@ -28,6 +28,11 @@ if userOS == "Linux" then
         updater.available = false
     end
 
+    -- If the app is flatpak'd then we disable by force the updater
+    if love.filesystem.exists("/.flatpak-info") then
+        updater.available = false
+    end
+
 else
     updater.available = true
 end


### PR DESCRIPTION
This PR force disables the updater when the flatpak sandbox is detected. I couldn't reproduce it on my hardware but it sometimes happens on user installs.