### PR TITLE
linux: Add a changelog section to the metainfo.xml file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -395,6 +395,7 @@ steps:
       chmod a+rx love/$LOVEBINARYDIRECTORY/sharp/Olympus.Sharp
       sed -i -e "s/BUILD_VERSION/$(Build.BuildNumber)/g" love/$LOVEBINARYDIRECTORY/io.github.everestapi.Olympus.metainfo.xml
       sed -i -e "s/BUILD_DATE/$(date '+%Y-%m-%d')/g" love/$LOVEBINARYDIRECTORY/io.github.everestapi.Olympus.metainfo.xml
+      sed -i -e "s|BUILD_CHANGELOG|$(<changelog.txt)|g" love/$LOVEBINARYDIRECTORY/io.github.everestapi.Olympus.metainfo.xml
       cp src/data/icon.png love/$LOVEBINARYDIRECTORY/olympus.png
       rm love/$LOVEBINARYDIRECTORY/lib/x86_64-linux-gnu/libz.so.1
       rm love/$LOVEBINARYDIRECTORY/usr/lib/x86_64-linux-gnu/libfreetype.so.6

--- a/lib-linux/io.github.everestapi.Olympus.metainfo.xml
+++ b/lib-linux/io.github.everestapi.Olympus.metainfo.xml
@@ -30,6 +30,8 @@
   
   <releases>
     <release version="BUILD_VERSION" date="BUILD_DATE"/>
+      <description>BUILD_CHANGELOG</description>
+    </release>
   </releases>
 
   <screenshots>


### PR DESCRIPTION
This PR enhances the flatpak/flathub integration by adding the changelog to the linux metainfo xml.
It simply pipes the content of `changelog.txt` during the building.