### PR TITLE
fix: Use the unsandboxed fs.isFile variant

### DIFF
--- a/src/updater.lua
+++ b/src/updater.lua
@@ -29,7 +29,7 @@ if userOS == "Linux" then
     end
 
     -- If the app is flatpak'd then we disable by force the updater
-    if love.filesystem.exists("/.flatpak-info") then
+    if fs.isFile("/.flatpak-info") then
         updater.available = false
     end
 


### PR DESCRIPTION
`love.filesystem.exists` is sandboxed by default  to the current directory it's ran in, thus `/.flatpak-info`, isn't available. Making use of `fs.isFile` make it work as expected