### PR TITLE
Use HttpClient everywhere, with compression when useful, and without IPv6

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,4 @@ and only contains the latest changes.
 Its purpose is to be shown in Olympus when updating.
 
 #changelog#
-∙ Linux: fixed Flatpak detection, self-updates should now be disabled properly
-∙ Added possibility to "hint" Olympus on the location of Celeste through an environment variable (OLYMPUS_FINDER_HINTS)
-∙ Reduced the amount of API calls to maddie480.ovh when loading the GameBanana categories list
+∙ Enabled compression and disabled IPv6 on API calls, hopefully fixing connection issues for some users

--- a/sharp/CmdGetLoennLatestVersion.cs
+++ b/sharp/CmdGetLoennLatestVersion.cs
@@ -1,9 +1,7 @@
 ﻿using MonoMod.Utils;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.IO;
-using System.Net;
+using System.Net.Http;
 
 namespace Olympus {
     public class CmdGetLoennLatestVersion : Cmd<Tuple<string, string>> {
@@ -12,14 +10,9 @@ namespace Olympus {
 
         public override Tuple<string, string> Run() {
             try {
-                HttpWebRequest req = (HttpWebRequest) WebRequest.Create("https://maddie480.ovh/celeste/loenn-versions");
-                req.UserAgent = "Olympus";
-                req.Timeout = 10000;
-                req.ReadWriteTimeout = 10000;
-                using (HttpWebResponse res = (HttpWebResponse) req.GetResponse())
-                using (StreamReader reader = new StreamReader(res.GetResponseStream()))
-                using (JsonTextReader json = new JsonTextReader(reader)) {
-                    JObject latestVersion = (JObject) JToken.ReadFrom(json);
+                using (HttpClient client = new HttpClientWithCompressionSupport()) {
+                    string json = client.GetStringAsync("https://maddie480.ovh/celeste/loenn-versions").Result;
+                    JObject latestVersion = (JObject) JToken.Parse(json);
                     return new Tuple<string, string>((string) latestVersion["tag_name"], GetDownloadLink((JArray) latestVersion["assets"]));
                 }
             } catch (Exception ex) {

--- a/sharp/CmdGetModIdToNameMap.cs
+++ b/sharp/CmdGetModIdToNameMap.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net;
+using System.Net.Http;
 using System.Text;
 
 namespace Olympus {
@@ -36,8 +36,8 @@ namespace Olympus {
 
             Console.Error.WriteLine($"[CmdGetIdToNameMap] Loading mod IDs from maddie480.ovh");
             map = tryRun(() => {
-                using (HttpWebResponse res = Connect("https://maddie480.ovh/celeste/mod_ids_to_names.json"))
-                using (Stream inputStream = res.GetResponseStream()) {
+                using (HttpClient wc = new HttpClientWithCompressionSupport())
+                using (Stream inputStream = wc.GetAsync("https://maddie480.ovh/celeste/mod_ids_to_names.json").Result.Content.ReadAsStream()) {
                     return getModIDsToNamesMap(inputStream);
                 }
             });

--- a/sharp/CmdInstallEverest.cs
+++ b/sharp/CmdInstallEverest.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.IO;
 using System.IO.Compression;
 using System.Net;
+using System.Net.Http;
 
 namespace Olympus {
     public partial class CmdInstallEverest : Cmd<string, string, string, string, IEnumerator> {
@@ -58,8 +59,8 @@ namespace Olympus {
 
                 try {
                     byte[] zipData;
-                    using (WebClient wc = new WebClient())
-                        zipData = wc.DownloadData(olympusMetaDownload);
+                    using (HttpClient wc = new HttpClientWithCompressionSupport())
+                        zipData = wc.GetByteArrayAsync(olympusMetaDownload).Result;
                     using (MemoryStream zipStream = new MemoryStream(zipData))
                     using (ZipArchive zip = new ZipArchive(zipStream, ZipArchiveMode.Read)) {
                         using (Stream sizeStream = zip.GetEntry("olympus-meta/size.txt").Open())

--- a/sharp/CmdUpdateAllMods.cs
+++ b/sharp/CmdUpdateAllMods.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Security.Cryptography;
 
 namespace Olympus {
@@ -193,8 +194,8 @@ namespace Olympus {
 
                 log($"Downloading last versions list from {modUpdaterDatabaseUrl}");
 
-                using (WebClient wc = new WebClient()) {
-                    string yamlData = wc.DownloadString(modUpdaterDatabaseUrl);
+                using (HttpClient wc = new HttpClientWithCompressionSupport()) {
+                    string yamlData = wc.GetStringAsync(modUpdaterDatabaseUrl).Result;
                     updateCatalog = YamlHelper.Deserializer.Deserialize<Dictionary<string, ModUpdateInfo>>(yamlData);
                     foreach (string name in updateCatalog.Keys) {
                         updateCatalog[name] = new ModUpdateInfo {
@@ -252,9 +253,9 @@ namespace Olympus {
         /// This should point to a running instance of https://github.com/maddie480/EverestUpdateCheckerServer.
         /// </summary>
         private static string getModUpdaterDatabaseUrl() {
-            using (WebClient wc = new WebClient()) {
+            using (HttpClient wc = new HttpClientWithCompressionSupport()) {
                 log("Fetching mod updater database URL");
-                return wc.DownloadString("https://everestapi.github.io/modupdater.txt").Trim();
+                return wc.GetStringAsync("https://everestapi.github.io/modupdater.txt").Result.Trim();
             }
         }
     }

--- a/sharp/CmdWebGet.cs
+++ b/sharp/CmdWebGet.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace Olympus {
     public class CmdWebGet : Cmd<string, byte[]> {
@@ -8,10 +10,10 @@ namespace Olympus {
 
         public override byte[] Run(string url) {
             try {
-                using (WebClient wc = new WebClient()) {
-                    wc.Headers.Set(HttpRequestHeader.UserAgent, $"Everest.Olympus.Sharp");
-                    wc.Headers.Set(HttpRequestHeader.Accept, "*/*");
-                    return wc.DownloadData(url);
+                using (HttpClient wc = new HttpClientWithCompressionSupport()) {
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
+                    return wc.Send(request).Content.ReadAsByteArrayAsync().Result;
                 }
             } catch (Exception e) {
                 throw new Exception($"Failed downloading {url}", e);

--- a/sharp/HttpClientWithCompressionSupport.cs
+++ b/sharp/HttpClientWithCompressionSupport.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Olympus {
+    public class CmdSetOlympusVersion : Cmd<string, string> {
+        public override string Run(string version) {
+            HttpClientWithCompressionSupport.Version = version;
+            return "ok";
+        }
+    }
+
+    /// <summary>
+    /// An HttpClient that supports compressed responses to save bandwidth, and uses IPv4 to work around issues for some users.
+    /// </summary>
+    public class HttpClientWithCompressionSupport : HttpClient {
+        public static string Version = "ERROR";
+
+        private static readonly Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>> connectCallback = async delegate(SocketsHttpConnectionContext ctx, CancellationToken token) {
+            if (ctx.DnsEndPoint.AddressFamily != AddressFamily.Unspecified && ctx.DnsEndPoint.AddressFamily != AddressFamily.InterNetwork) {
+                throw new InvalidOperationException("no IPv4 address");
+            }
+
+            Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            try {
+                await socket.ConnectAsync(new DnsEndPoint(ctx.DnsEndPoint.Host, ctx.DnsEndPoint.Port, AddressFamily.InterNetwork), token).ConfigureAwait(false);
+                return new NetworkStream(socket, true);
+            }
+            catch (Exception) {
+                socket.Dispose();
+                throw;
+            }
+        };
+
+        private static readonly SocketsHttpHandler compressedHandler = new SocketsHttpHandler {
+            AutomaticDecompression = DecompressionMethods.All,
+            ConnectCallback = connectCallback
+        };
+
+        private static readonly SocketsHttpHandler regularHandler = new SocketsHttpHandler {
+            AutomaticDecompression = DecompressionMethods.None,
+            ConnectCallback = connectCallback
+        };
+
+        public HttpClientWithCompressionSupport(bool enableCompression = true) : base(enableCompression ? compressedHandler : regularHandler, disposeHandler: false) {
+            DefaultRequestHeaders.Add("User-Agent", $"Olympus/{Version}");
+        }
+    }
+}

--- a/src/main.lua
+++ b/src/main.lua
@@ -203,6 +203,7 @@ function love.load(args)
         love.window.showMessageBox("Olympus.Sharp Startup Error", "Failed loading Olympus.Sharp: " .. tostring(sharpError), "error")
     else
         threader.routine(function()
+            sharp.setOlympusVersion(utils.trim(utils.load("version.txt") or "ERROR")):result()
             sharp.getModIdToNameMap(fs.joinpath(fs.getStorageDir(), "cached-mod-ids-to-names.json"))
         end)
     end


### PR DESCRIPTION
People seem to **really** struggle with IPv6, and this was "fixed" in Everest by disabling it entirely, through a class called [CompressedHttpClient](https://github.com/EverestAPI/Everest/blob/dev/Celeste.Mod.mm/Mod/Helpers/CompressedHttpClient.cs). That class also enables automatic compression, to save some bandwidth when downloading JSON and such.

I'm recycling the class here, as `HttpClientWithCompressionSupport` because compression can be disabled: compression isn't useful when downloading zips, and [it apparently blocks access to the Content-Length header](https://github.com/dotnet/runtime/issues/95708), which we need to be able to show a progress bar...

Now nothing uses `HttpWebRequest` or `WebClient` anymore... except `launcher-winforms`, but we don't talk about that one.