### PR TITLE
fix(flatpak-wrapper): Update flatpak-wrapper to add double quotes in the case of spaces in the path

### DIFF
--- a/lib-linux/flatpak-wrapper
+++ b/lib-linux/flatpak-wrapper
@@ -1,4 +1,4 @@
 #!/bin/sh
 #
 # A linux-only script that allows the flatpak version of Olympus to be able to start Celeste
-exec flatpak-spawn --host $@
+exec flatpak-spawn --host "$@"


### PR DESCRIPTION
Should fix executing celeste or everest when olympus is in a flatpak and when the path to celeste has spaces in it
fixes #126