### PR TITLE
Add check for azure builds json data without a `value` property

### DIFF
--- a/src/updater.lua
+++ b/src/updater.lua
@@ -77,6 +77,10 @@ function updater.check(auto)
             return false
         end
         builds = builds.value
+        if not builds then
+            notify("Error downloading builds list: Invalid olympus builds json (missing value property)")
+            return false
+        end
 
         for bi = 1, #builds do
             local build = builds[bi]


### PR DESCRIPTION
Fixes issues like:
```lua
Error

threader.lua:79: routine#10>updater.lua:50<updater.lua:50 died:
updater.lua:81: attempt to get length of local 'builds' (a nil value)
stack traceback:
updater.lua:81: in function 'fun'
threader.lua:485: in function <threader.lua:484>
[C]: in function 'xpcall'
threader.lua:483: in function <threader.lua:479>


Traceback

[love "callbacks.lua"]:228: in function 'handler'
[C]: in function 'error'
threader.lua:79: in function 'update'
threader.lua:544: in function 'update'
main.lua:714: in function 'update'
[love "callbacks.lua"]:162: in function 'orig'
main.lua:102: in function <main.lua:99>
[C]: in function 'xpcall'
```

Unsure why azure returns an empty json (or just one without a `value` property) but an in-app error is much preferable.