### PR TITLE
Auto-disable logic fixes + some cleanup

### DIFF
--- a/sharp/Olympus.Sharp.csproj
+++ b/sharp/Olympus.Sharp.csproj
@@ -20,8 +20,6 @@
     <DefineConstants>MACOS</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
-
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="MonoMod" Version="22.01.04.03" />


### PR DESCRIPTION
This fixes some faulty logic in the auto-disable feature in cases like the following:
Say mods A and B depend on C. They're all enabled, and B is favorited. Now say we disable A. Previously, C would be prompted to be disabled as "unnecessary". This fixes that.

Also some cleanup and refactoring for nicer code.