### PR TITLE
Fix preset "replace" crash

### DIFF
--- a/src/scenes/modlist.lua
+++ b/src/scenes/modlist.lua
@@ -328,7 +328,7 @@ local function enableMods(mods)
             handleModEnabledStateChange(mod, true)
         end
     end
-    
+
     updateEnabledModCountLabel()
     writeBlacklist()
 end
@@ -345,7 +345,7 @@ local function disableMods(mods)
             handleModEnabledStateChange(mod, false)
         end
     end
-    
+
     updateEnabledModCountLabel()
     writeBlacklist()
 end


### PR DESCRIPTION
Accidentally left an old function reference

Also small optimization for displaying enabled mod count when enabling/disabling multiple mods