### PR TITLE
fix: force mods path to be capitalized

### DIFF
--- a/src/scenes/modlist.lua
+++ b/src/scenes/modlist.lua
@@ -876,7 +876,7 @@ local function buildPresetsUI()
         uie.paneled.row({
             uie.button(lang.get("edit_modpresets_txt"), function()
                 local root = config.installs[config.install].path
-                utils.openFile(fs.joinpath(root, lang.get("mods"), "modpresets.txt"))
+                utils.openFile(fs.joinpath(root, "Mods", "modpresets.txt"))
             end),
             uie.row({
                 presetField,


### PR DESCRIPTION
I noticed that the "Edit modpresets.txt" button was [pulling the mods folder name from the lang file](https://github.com/EverestAPI/Olympus/blob/2959f60fc33a0bd5c3a6805f439bf69c02b3bbfe/src/scenes/modlist.lua#L879)

This breaks on Linux-based file systems that care about capitalization since the lang has this set to `mods`, and the name of the folder is `Mods`.

<img width="1352" height="357" alt="image" src="https://github.com/user-attachments/assets/644f57b5-69d7-40b2-9a78-2be9c52e4af0" />


This also fixes a bug if you set the language to french, since that would make the button direct to `../mods activés/modpresets.txt`. Everest seems to [use "Mods" as the folder name regardless of language](https://github.com/EverestAPI/Everest/blob/14bea084fe37a3dd8322d03d14670e701ed21273/MiniInstaller/Globals.cs#L56), so it shouldn't change depending on the olympus language

This PR just hardcodes the mod folder name to "Mods", as it is in Everest