### PR TITLE
fix: Actions not refreshing modlist while mods are filtered by "Enabled only"

### DIFF
--- a/src/scenes/modlist.lua
+++ b/src/scenes/modlist.lua
@@ -1070,11 +1070,13 @@ function scene.reload()
                     uie.label(""):with(verticalCenter):as("enabledModCountLabel"),
                     uie.button(lang.get("enable_all"), function()
                         enableMods(scene.modsByPath)
+                        refreshVisibleMods()
                         writeBlacklist()
                     end):with({ enabled = false }):as("enableAllButton"),
                     uie.button(lang.get("disable_all"), function()
                         -- don't disable favorites
                         disableMods(scene.modsByPath, false)
+                        refreshVisibleMods()
                         writeBlacklist()
                     end):with({ enabled = false }):as("disableAllButton"),
                 }):with(uiu.rightbound)

--- a/src/scenes/modlist.lua
+++ b/src/scenes/modlist.lua
@@ -338,6 +338,7 @@ local function handleModEnabledStateChange(mod, enabling)
     updateLabelTextForDependencies(mod)
     updateWarningButtonForMod(mod)
     updateWarningButtonForDependents(mod)
+    refreshVisibleMods()
 end
 
 -- enable mods on the UI


### PR DESCRIPTION
When pressing `Enable All` or `Disable All` with the `Enabled only` checkbox is ticked, the modlist does not update to include newly enabled mods or exclude newly disabled mods.

Additionally, when disabling a mod with the `Enabled only` checkbox ticked, the modlist does not hide the disabled mod.

Now the modlist refreshes when either action is performed.